### PR TITLE
add filter to skip get_posts

### DIFF
--- a/includes/api/api-field-group.php
+++ b/includes/api/api-field-group.php
@@ -165,17 +165,19 @@ function acf_get_field_groups( $args = false ) {
 	// query DB for child ids
 	} else {
 		
-		// query
-		$posts = get_posts(array(
-			'post_type'					=> 'acf-field-group',
-			'posts_per_page'			=> -1,
-			'orderby' 					=> 'menu_order title',
-			'order' 					=> 'asc',
-			'suppress_filters'			=> false, // allow WPML to modify the query
-			'post_status'				=> array('publish', 'acf-disabled'),
-			'update_post_meta_cache'	=> false
-		));
-		
+		$skip_database_field_groups = apply_filters('acf/skip_database_field_groups', false);
+		if(!$skip_database_field_groups) {
+			// query
+			$posts = get_posts(array(
+				'post_type'					=> 'acf-field-group',
+				'posts_per_page'			=> -1,
+				'orderby' 					=> 'menu_order title',
+				'order' 					=> 'asc',
+				'suppress_filters'			=> false, // allow WPML to modify the query
+				'post_status'				=> array('publish', 'acf-disabled'),
+				'update_post_meta_cache'	=> false
+			));
+		}		
 		
 		// loop
 		if( $posts ) {


### PR DESCRIPTION
hey 🤚 

we are using ACF-Pro on a quiet large news publisher website. having around 600k+ posts using a ton of ACF fields, using php/json loaded fields. 


due to the nature of WP - we ran into issues with this call to `get_posts` - and we dont even need it as said above we are only using the php loaded fields.


to overcome, bypass this query, we added

```php

 add_filter('posts_pre_query', [$this, 'acf_posts_pre_query'], 15, 2)


public function acf_posts_pre_query($posts, \WP_Query $query)
    {
        if (is_object($query) && property_exists($query, 'query_vars') && $query->query_vars['post_type'] == 'acf-field-group' && ! $this->debug_enabled()) {
            return [];
        }
        return $posts;
    }

```

 whilst still be able to use it on dev-systems.

however it would be really nice to ship with a built in filter where we just can return true/false, and not rely on the query_vars thing (feels hacky)


reference: https://github.com/KroneMultimedia/plugin-hacks/blob/master/src/Core.php