### PR TITLE
 Fixes input append height in Gutenberg

### DIFF
--- a/assets/build/css/_fields.scss
+++ b/assets/build/css/_fields.scss
@@ -526,6 +526,10 @@
 	
 	background: #F4F4F4;
 	border: #DFDFDF solid 1px;
+	
+	.block-editor-page & {
+		height: auto;
+	}
 }
 
 .acf-input-prepend {


### PR DESCRIPTION
Input append and prepend shows in smaller height than needed. This fixes it.
![Screen Shot 2019-03-25 at 12 33 03](https://user-images.githubusercontent.com/4457340/54913957-94ff5f80-4efc-11e9-967b-875583a5f8d2.png)
