### PR TITLE
Fix a wrong translation in acf-pl_PL.po

### DIFF
--- a/lang/acf-pl_PL.po
+++ b/lang/acf-pl_PL.po
@@ -3253,7 +3253,7 @@ msgstr "Minimalna liczba wierszy"
 
 #: pro/fields/class-acf-field-repeater.php:433
 msgid "Maximum Rows"
-msgstr "Minimalna liczba wierszy"
+msgstr "Maksymalna liczba wierszy"
 
 #: pro/locations/class-acf-location-options-page.php:79
 msgid "No options pages exist"


### PR DESCRIPTION
"Maximum Rows" should be translated to "Maksymalna liczba wierszy", not to "Minimalna liczba wierszy".