### PR TITLE
Fix get_field() performance bottleneck on local fields (~40%)

### DIFF
--- a/includes/acf-field-functions.php
+++ b/includes/acf-field-functions.php
@@ -20,21 +20,20 @@ function acf_get_field( $id = 0 ) {
 	if( is_object($id) ) {
 		$id = $id->ID;
 	}
+    
+    // Check local fields first.
+	if( acf_is_local_field($id) ) {
+		return acf_get_local_field( $id );
+	}
 	
 	// Check store.
 	$store = acf_get_store( 'fields' );
 	if( $store->has( $id ) ) {
 		return $store->get( $id );
 	}
-	
-	// Check local fields first.
-	if( acf_is_local_field($id) ) {
-		$field = acf_get_local_field( $id );
-	
-	// Then check database.
-	} else {
-		$field = acf_get_raw_field( $id );
-	}
+    
+    // Then check database.
+    $field = acf_get_raw_field( $id );
 	
 	// Bail early if no field.
 	if( !$field ) {

--- a/includes/local-fields.php
+++ b/includes/local-fields.php
@@ -275,7 +275,25 @@ function acf_add_local_fields( $fields = array() ) {
 	
 	// Add each field.
 	foreach( $fields as $field ) {
+        
+        // Validate field.
+        $field = acf_validate_field( $field );
+        
+        // Set input prefix.
+        $field['prefix'] = 'acf';
+        
+        /**
+         * Filters the $field array after it has been loaded.
+         *
+         * @date	12/02/2014
+         * @since	5.0.0
+         *
+         * @param	array The field array.
+         */
+        $field = apply_filters( "acf/load_field", $field );
+        
 		acf_add_local_field( $field, true );
+        
 	}
 }
 


### PR DESCRIPTION
Hello,

I was working on a faster alternative to `get_field()` function when I discovered a performance bottleneck on local fields.

Description:

The problem come from `acf_get_field()` function, which is called every time `get_field()` is invoked. What it does for each fields:

- Check first if the field is local
- If the local field is found:
- - Apply `acf_validate_field()`
- - Apply `$field['prefix'] = 'acf';`
- - Apply `acf/load_field` filters
- - Push the field into the buffering `store('fields')` for the next call.

I was able to gain ~40% performance on `get_field()` calls with local fields by doing so:

If the field is local: Do not process `validate`, `prefix`, `acf/load_field` in `acf_get_field()`.
Inject it during the local fields registration, in `acf_add_local_fields()`:

- Apply `acf_validate_field()`
- Apply `$field['prefix'] = 'acf';`
- Apply `acf/load_field` filters

Finally, in `acf_get_field()`, if the field is local, then directly return the local field.

I ran a benchmark on local environment, on a page with 200 `get_field()` on 200 different fields (local PHP field group):
- 0.0272 sec
- 0.0308 sec
- 0.0260 sec

With the fix in this pull request:
- 0.0179 sec
- 0.0185 sec
- 0.0167 sec

I ran some tests on `acf/load_field` filter, and it works as expected.

Hope it helps :)

Regards.