### PR TITLE
fix: check for non empty search arg

### DIFF
--- a/includes/fields/class-acf-field-page_link.php
+++ b/includes/fields/class-acf-field-page_link.php
@@ -203,7 +203,7 @@ class acf_field_page_link extends acf_field {
 				
 				
 				// order posts by search
-				if( $is_search && empty($args['orderby']) ) {
+				if( $is_search && empty($args['orderby']) && !empty($args['s']) ) {
 					
 					$posts = acf_order_by_search( $posts, $args['s'] );
 					

--- a/includes/fields/class-acf-field-post_object.php
+++ b/includes/fields/class-acf-field-post_object.php
@@ -199,7 +199,7 @@ class acf_field_post_object extends acf_field {
 			
 			
 			// order posts by search
-			if( $is_search && empty($args['orderby']) ) {
+			if( $is_search && empty($args['orderby']) && !empty($args['s']) ) {
 				
 				$posts = acf_order_by_search( $posts, $args['s'] );
 				

--- a/includes/fields/class-acf-field-relationship.php
+++ b/includes/fields/class-acf-field-relationship.php
@@ -250,7 +250,7 @@ class acf_field_relationship extends acf_field {
 			
 			
 			// order posts by search
-			if( $is_search && empty($args['orderby']) ) {
+			if( $is_search && empty($args['orderby']) && !empty($args['s']) ) {
 				
 				$posts = acf_order_by_search( $posts, $args['s'] );
 				


### PR DESCRIPTION
Hi, @elliotcondon 

In case we're using `acf/fields/post_object/query` and unsetted the `s` arg in order to use something like `post__in` this cause a warning.
Here's the fix 😃 