### PR TITLE
Fixed taxonomy field load/save function to get right post id if field…

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -2737,8 +2737,26 @@ function acf_get_post_id_info( $post_id = 0 ) {
 			
 			$info['type'] = $type;
 			$info['id'] = (int) $id;
-		
-		// option	
+
+        // block
+        } elseif ($type == 'block') {
+
+        $info['type'] = 'post';
+        $realPostID = 0;
+        if(isset($GLOBALS['post']) && isset($GLOBALS['post']->ID)) {
+            $realPostID = $GLOBALS['post']->ID;
+        } elseif(isset($_REQUEST['post_id']) && is_numeric($_REQUEST['post_id'])) {
+            $realPostID = $_REQUEST['post_id'];
+        } elseif(isset($GLOBALS['HTTP_RAW_POST_DATA'])) {
+            $rawPostData = $GLOBALS['HTTP_RAW_POST_DATA'];
+            $postData = json_decode($rawPostData, true);
+            if(isset($postData['id'])) {
+                $realPostID = $postData['id'];
+            }
+        }
+        $info['id'] = (int) $realPostID;
+        
+		// option
 		} else {
 			
 			$info['type'] = 'option';


### PR DESCRIPTION
… is located in a block

If Taxonomy field is added to a block, the method acf_get_post_id_info() tries to get the right post id but fails because of the unrecognized syntax „block_38u4ndfd8“ of $post_id. Means taxonomy terms are not loaded from/saved to the post/page.

Tried to implement it in a way that all cases are covered: save, update, auto-save, load, ...

If there is a better/more robust way to get the (parent) Post ID in this part of code i'm happy to hear about.