### PR TITLE
Update class-acf-field-wysiwyg.php

### DIFF
--- a/includes/fields/class-acf-field-wysiwyg.php
+++ b/includes/fields/class-acf-field-wysiwyg.php
@@ -173,7 +173,9 @@ class acf_field_wysiwyg extends acf_field {
 			
 			if( $rows ) {
 				foreach( $rows as $i => $row ) { 
-					$data[ $key ][ $i ] = implode(',', $row);
+					if ( is_array( $row ) ) {
+					  $data[ $key ][ $i ] = implode(',', $row);
+					}
 				}
 			}
 		}}


### PR DESCRIPTION
added a condition to see if $row is an array or not. That should solves the warning on the backend when debug mode is on