### PR TITLE
Copy readonly/disable functionality from date_picker

### DIFF
--- a/includes/fields/class-acf-field-date_time_picker.php
+++ b/includes/fields/class-acf-field-date_time_picker.php
@@ -140,6 +140,13 @@ class acf_field_date_and_time_picker extends acf_field {
 			'value'					=> $display_value,
 		);
 		
+		// special attributes
+		foreach( array( 'readonly', 'disabled' ) as $k ) {
+			if( !empty($field[ $k ]) ) {
+				$text_input[ $k ] = $k;
+			}
+		}
+		
 		
 		// html
 		?>


### PR DESCRIPTION
The date_picker field type has code to respect the readonly and disabled flags but the date_time_picker field type does not. This copies that functionality into date_time_picker as well