### PR TITLE
add pdf thumbnail sizes to attachment data array

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -3181,6 +3181,11 @@ function acf_get_attachment( $attachment ) {
 				$sizes_id = $featured_id;
 			}	
 			break;
+		case 'application':
+			if ( $subtype === 'pdf' ) {
+				$sizes_id = $attachment->ID;
+			}
+			break;
 	}
 
 	// Load array of image sizes.


### PR DESCRIPTION
With version 4.7 Wordpress got [enhanced pdf support](https://make.wordpress.org/core/2016/11/15/enhanced-pdf-support-4-7/) which automatically created thumbnails of the first page in different sizes when uploading a PDF.

It would be great if these thumbnails were automatically included in the attachment data array I get from a file field.

With my commit all sizes are added to the attachment data array.
But there is place for some optimization to only return thumbnail sizes possible for PDF's. By default these are:

`
$fallback_sizes = array(
	'thumbnail',
	'medium',
	'large',
);
`

These can be extended by the filter `fallback_intermediate_image_sizes` [(doc)](https://developer.wordpress.org/reference/hooks/fallback_intermediate_image_sizes/) to add other image Sizes which were registered by the `add_image_size()` function.

I hope you find this pull request useful. Especially for download lists, which would be generated by repeater and file field, it would be handy to output the PDF thumbnail directly from the sizes array, without having to get the thumbnails via `wp_get_attachment_image_url()`.

Thanks for your great plugin!
Martin