### PR TITLE
acf_maybe_get_field($strict = false) by default

### DIFF
--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -156,7 +156,7 @@ function get_field_object( $selector, $post_id = false, $format_value = true, $l
 *  @param   $strict (boolean) if true, return a field only when a field key is found.
 *  @return  $field (array)
 */
-function acf_maybe_get_field( $selector, $post_id = false, $strict = true ) {
+function acf_maybe_get_field( $selector, $post_id = false, $strict = false ) {
 
 	// init
 	acf_init();


### PR DESCRIPTION
My [gist](https://gist.github.com/drzraf/f9f1bbbe0177be9ce78d344061a376a4) had to be rerolled after whitespaces changes affected this file.
See #32 for the reason for this proposal (but feel free to suggest another workaround).
See also #395