### PR TITLE
Fix featured image validation error

### DIFF
--- a/assets/build/js/acf-input.js
+++ b/assets/build/js/acf-input.js
@@ -6716,6 +6716,10 @@
 						if( selected && selected.indexOf(attributes.id) > -1 ) {
 							this.$el.addClass('acf-selected');
 						}
+					} else {
+						
+						// remove errors
+						attributes.acf_errors = false;
 					}
 										
 					// render


### PR DESCRIPTION
There is currently an issue when opening the library from the featured image section after opening it from an ACF field that contains validation rules (see #376).  

The `acf_errors` attribute must be reset when rendering an attachment that is not in an ACF controlled modal.  