### PR TITLE
Check if value is string before applying filter, fixes #564

### DIFF
--- a/includes/fields/class-acf-field-wysiwyg.php
+++ b/includes/fields/class-acf-field-wysiwyg.php
@@ -428,12 +428,15 @@ if ( ! class_exists( 'acf_field_wysiwyg' ) ) :
 				return $value;
 
 			}
+			
+			if ( is_string( $value ) ) {
 
-			// apply filters
-			$value = apply_filters( 'acf_the_content', $value );
+				// apply filters
+				$value = apply_filters( 'acf_the_content', $value );
 
-			// follow the_content function in /wp-includes/post-template.php
-			$value = str_replace( ']]>', ']]&gt;', $value );
+				// follow the_content function in /wp-includes/post-template.php
+				$value = str_replace( ']]>', ']]&gt;', $value );
+			}
 
 			return $value;
 		}


### PR DESCRIPTION
In my setup, I have a `clone` field that is represented as flexible content. Within this flexible content, 3 different high level fields exist: clone (flexible content), or post objects.

When nested Flexible Content > Flexible Content > Content (WYSIWYG in this case), ACF triggers `apply_filters` from `wysiwyg` field. The input `$value` is an array in my scenario, which causes the admin panel to throw an error. This just adds a string check before applying the filter.