### PR TITLE
fix(rest): get route from filter arg instead of $GLOBALS

### DIFF
--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -19,7 +19,7 @@ class ACF_Rest_Api {
 	private $embed_links;
 
 	public function __construct() {
-		add_filter( 'rest_request_before_callbacks', array( $this, 'initialize' ), 10, 3 );
+		add_filter( 'rest_pre_dispatch', array( $this, 'initialize' ), 10, 3 );
 	}
 
 	public function initialize( $response, $handler, $request ) {

--- a/includes/rest-api/class-acf-rest-api.php
+++ b/includes/rest-api/class-acf-rest-api.php
@@ -19,17 +19,17 @@ class ACF_Rest_Api {
 	private $embed_links;
 
 	public function __construct() {
-		add_action( 'rest_api_init', array( $this, 'initialize' ) );
+		add_filter( 'rest_request_before_callbacks', array( $this, 'initialize' ), 10, 3 );
 	}
 
-	public function initialize() {
+	public function initialize( $response, $handler, $request ) {
 		if ( ! acf_get_setting( 'rest_api_enabled' ) ) {
 			return;
 		}
 
 		// Parse request and set the object for local access.
 		$this->request = new ACF_Rest_Request();
-		$this->request->parse_request();
+		$this->request->parse_request( $request );
 
 		// Register the 'acf' REST property.
 		$this->register_field();

--- a/includes/rest-api/class-acf-rest-request.php
+++ b/includes/rest-api/class-acf-rest-request.php
@@ -51,9 +51,9 @@ class ACF_Rest_Request {
 	/**
 	 * Determine all required information from the current request.
 	 */
-	public function parse_request() {
+	public function parse_request( $request ) {
 		$this->set_http_method();
-		$this->set_current_route();
+		$this->set_current_route( $request );
 		$this->build_supported_routes();
 		$this->set_url_params();
 		$this->set_object_types();
@@ -102,8 +102,8 @@ class ACF_Rest_Request {
 	/**
 	 * Get the current REST route as determined by WordPress.
 	 */
-	private function set_current_route() {
-		$this->current_route = empty( $GLOBALS['wp']->query_vars['rest_route'] ) ? null : $GLOBALS['wp']->query_vars['rest_route'];
+	private function set_current_route( $request ) {
+		$this->current_route = $request->get_route();
 	}
 
 	/**


### PR DESCRIPTION
When a REST request comes from WordPress own **`rest_do_request`** function, `$GLOBALS['wp']->query_vars['rest_route']` is never set, so ACF bails and the ACF fields aren't added to the response.\* 

Here's the relevant issue on the support forums: https://support.advancedcustomfields.com/forums/topic/acf-fields-now-showing-in-rest_do_request-result/

Instead, we can get the rest route from the request instance that is passed to various filters, such as [`rest_pre_dispatch`](https://developer.wordpress.org/reference/hooks/rest_pre_dispatch/), [`rest_post_dispatch`](https://developer.wordpress.org/reference/hooks/rest_post_dispatch/) and [`rest_request_before_callbacks`](https://developer.wordpress.org/reference/hooks/rest_request_before_callbacks/), which sounded like the most fitting one to me.
___
\* And even if it could read the route, there can be many requests to handle for one `rest_api_init`, since `rest_do_request` can be called many times, reusing the same REST Server instance. So a filter that runs for each request is necessary no matter where the route information comes from, otherwise the ACF integration works only for the first request (when `rest_api_init` is called) and then uses an outdated route.