### PR TITLE
Usage of strtolower breaks accented translations

### DIFF
--- a/includes/fields/class-acf-field-taxonomy.php
+++ b/includes/fields/class-acf-field-taxonomy.php
@@ -670,7 +670,7 @@ if ( ! class_exists( 'acf_field_taxonomy' ) ) :
 			// vars
 			$args = array(
 				'taxonomy'         => $field['taxonomy'],
-				'show_option_none' => sprintf( _x( 'No %s', 'No terms', 'acf' ), strtolower( $taxonomy_obj->labels->name ) ),
+				'show_option_none' => sprintf( _x( 'No %s', 'No terms', 'acf' ), mb_strtolower( $taxonomy_obj->labels->name ) ),
 				'hide_empty'       => false,
 				'style'            => 'none',
 				'walker'           => new ACF_Taxonomy_Field_Walker( $field ),


### PR DESCRIPTION
This fixes the issue #647
Using `mb_strtolower` keeps the accented chars used in many language.

It surely improves the French default `Catégorie` name.