### PR TITLE
Resolve "(no title)" in ClassicPress

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -1561,7 +1561,7 @@ function acf_get_post_title( $post = 0, $is_search = false ) {
 	}
 
 	// title
-	$title = get_the_title( $post->ID );
+	$title = $post->post_title;
 
 	// empty
 	if ( $title === '' ) {


### PR DESCRIPTION
In the frontend form - acf_form( ) - select option shows "(no title)", even if already filled out.