### PR TITLE
Fix "(no title)" if 'the_title' hook is used

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -1561,7 +1561,7 @@ function acf_get_post_title( $post = 0, $is_search = false ) {
 	}
 
 	// title
-	$title = get_the_title( $post->ID );
+	$title = $post->post_title;
 
 	// empty
 	if ( $title === '' ) {


### PR DESCRIPTION
When the 'the_title' hook is used (e.g. add_filter( 'the_title', 'callback' ) ), select option display for field type Post Object displays "(no title)" even if already filled out (i.e. acf_form ( ) in the frontend)