### PR TITLE
Fix Dutch translation for "Minimum rows reached ({min} rows)"

### DIFF
--- a/lang/pro/acf-nl_NL.po
+++ b/lang/pro/acf-nl_NL.po
@@ -570,7 +570,7 @@ msgstr "Herhalen"
 #: pro/fields/class-acf-field-repeater.php:53,
 #: pro/fields/class-acf-field-repeater.php:423
 msgid "Minimum rows reached ({min} rows)"
-msgstr "Minimum aantal rijen bereikt ({max} rijen)"
+msgstr "Minimum aantal rijen bereikt ({min} rijen)"
 
 #: pro/fields/class-acf-field-repeater.php:54
 msgid "Maximum rows reached ({max} rows)"


### PR DESCRIPTION
Fixes the translation for Dutch translation of  "Minimum rows reached ({min} rows)" to include the {min} keyword instead of {max}.

This will fix a broken error message: "Minimum aantal rijen bereikt ({max} rijen)" where ""Minimum aantal rijen bereikt (1 rijen)" is expected.