### PR TITLE
Register taxonomies before CPTs to prevent URL structure errors

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -269,8 +269,8 @@ if ( ! class_exists( 'ACF' ) ) {
 
 			// Add post types and taxonomies.
 			if ( acf_get_setting( 'enable_post_types' ) ) {
-				acf_include( 'includes/post-types/class-acf-post-type.php' );
 				acf_include( 'includes/post-types/class-acf-taxonomy.php' );
+				acf_include( 'includes/post-types/class-acf-post-type.php' );
 			}
 
 			// Include fields.


### PR DESCRIPTION
Closes #819.

This PR swap around acf_include for post-types/taxonomies so that taxonomies are registered first.