### PR TITLE
Update class-acf-field-select.php

### DIFF
--- a/includes/fields/class-acf-field-select.php
+++ b/includes/fields/class-acf-field-select.php
@@ -293,7 +293,7 @@ if ( ! class_exists( 'acf_field_select' ) ) :
 				'data-allow_null'  => $field['allow_null'],
 			);
 
-			if ( $field['aria-label'] ) {
+			if ( isset( $field['aria-label'] ) && ! empty( $field['aria-label'] ) ) {
 				$select['aria-label'] = $field['aria-label'];
 			}
 


### PR DESCRIPTION
Fix for this error message: "Warning : Undefined array key "aria-label" -> wp-content/plugins/advanced-custom-fields-pro/includes/fields/class-acf-field-select.php:296"