### PR TITLE
Fix PHPDoc return types of `get_fields()` and `get_field_objects()`

### DIFF
--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -367,7 +367,7 @@ function acf_maybe_get_sub_field( $selectors, $post_id = false, $strict = true )
  * @param boolean $format_value Whether or not to format the field value.
  * @param boolean $escape_html  Should the field return a HTML safe formatted value if $format_value is true.
  *
- * @return array associative array where field name => field value
+ * @return array|false associative array where field name => field value
  */
 function get_fields( $post_id = false, $format_value = true, $escape_html = false ) {
 
@@ -407,7 +407,7 @@ function get_fields( $post_id = false, $format_value = true, $escape_html = fals
  * @param boolean $load_value   Whether or not to load the field value.
  * @param boolean $escape_html  Should the field return a HTML safe formatted value if $format_value is true.
  *
- * @return array associative array where field name => field
+ * @return array|false associative array where field name => field
  */
 function get_field_objects( $post_id = false, $format_value = true, $load_value = true, $escape_html = false ) {
 


### PR DESCRIPTION
Before 6.2.5 and 6.2.6 these were something like `@return  (array) <description>` and static analysis tools were ignoring the invalid `(array)` PHPDoc and basically falling back to `mixed`. But then they were changed to `@return array` and the PHPDoc was picked up and started to cause false-positive reports via PHPStan in my case since the functions can in reality return false.

There would be many more places to adapt I guess, but I wanted to only touch what was causing issues for me.