### PR TITLE
Please don't break PHP compatibility with one line!

### DIFF
--- a/includes/class-acf-site-health.php
+++ b/includes/class-acf-site-health.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'ACF_Site_Health' ) ) {
 		 *
 		 * @var string
 		 */
-		public string $option_name = 'acf_site_health';
+		public $option_name = 'acf_site_health';
 
 		/**
 		 * Constructs the ACF_Site_Health class.


### PR DESCRIPTION
WordPress also works with PHP 7.2.24+ even though PHP 7.4 or greater is recommended.