### PR TITLE
fix: harden previous security fix to include $_REQUEST as well

### DIFF
--- a/includes/post-types/class-acf-post-type.php
+++ b/includes/post-types/class-acf-post-type.php
@@ -649,12 +649,15 @@ if ( ! class_exists( 'ACF_Post_Type' ) ) {
 			}
 
 			$original_post = $_POST; //phpcs:ignore -- Only used as temporary storage to prevent CSRFs in callbacks.
+			$original_request = $_REQUEST; //phpcs:ignore -- Only used as temporary storage to prevent CSRFs in callbacks.
 			$_POST         = array();
+			$_REQUEST      = array();
 			$return        = false;
 			if ( is_callable( $original_cb ) ) {
 				$return = call_user_func( $original_cb, $post );
 			}
 			$_POST = $original_post;
+			$_REQUEST = $original_request;
 			return $return;
 		}
 

--- a/includes/post-types/class-acf-taxonomy.php
+++ b/includes/post-types/class-acf-taxonomy.php
@@ -535,12 +535,15 @@ if ( ! class_exists( 'ACF_Taxonomy' ) ) {
 			}
 
 			$original_post = $_POST; //phpcs:ignore -- Only used as temporary storage to prevent CSRFs in callbacks.
+			$original_request = $_REQUEST; //phpcs:ignore -- Only used as temporary storage to prevent CSRFs in callbacks.
 			$_POST         = array();
+			$_REQUEST      = array();
 			$return        = false;
 			if ( is_callable( $original_cb ) ) {
 				$return = call_user_func( $original_cb, $post, $tax );
 			}
 			$_POST = $original_post;
+			$_REQUEST = $original_request;
 			return $return;
 		}
 


### PR DESCRIPTION
This PR applies the hardening change that the WordPress.org team applied when they changed the plugin, as tracked here (at the bottom): https://plugins.trac.wordpress.org/changeset?old_path=%2Fadvanced-custom-fields%2Ftrunk%2Fincludes&old=3167679&new_path=%2Fadvanced-custom-fields%2Ftrunk%2Fincludes&new=3167679&sfp_email=&sfph_mail=

It includes the change to include $_REQUEST in the security hardening that was previously applied.

PS: I know you have an internal repo so not expecting this to be merged, just giving you an easy way of seeing the change :).