### PR TITLE
Added Dutch FORMAL ACF Pro strings (based on 6.3.7 .pot file)

### DIFF
--- a/lang/pro/acf-nl_NL_formal.po
+++ b/lang/pro/acf-nl_NL_formal.po
@@ -1,0 +1,1462 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Advanced Custom Fields PRO\n"
+"Report-Msgid-Bugs-To: https://support.advancedcustomfields.com\n"
+"POT-Creation-Date: 2024-10-02 12:08+0000\n"
+"PO-Revision-Date: 2024-10-17 10:54+0200\n"
+"Last-Translator: Toine Rademacher (toineenzo) <hi@toine.zip>\n"
+"Language-Team: WP Engine <support@advancedcustomfields.com>\n"
+"Language: nl_NL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.5\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-WPHeader: acf.php\n"
+"X-Textdomain-Support: yes\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+
+#: pro/acf-pro.php:21
+msgid "Advanced Custom Fields PRO"
+msgstr "Advanced Custom Fields PRO"
+
+#: pro/acf-pro.php:175
+msgid ""
+"Your ACF PRO license is no longer active. Please renew to continue to have "
+"access to updates, support, & PRO features."
+msgstr ""
+"Uw ACF PRO licentie is niet langer actief. Verleng om toegang te blijven "
+"houden tot updates, ondersteuning en PRO functies."
+
+#: pro/acf-pro.php:172
+msgid ""
+"Your license has expired. Please renew to continue to have access to "
+"updates, support &amp; PRO features."
+msgstr ""
+"Uw licentie is verlopen. Verleng om toegang te blijven houden tot updates, "
+"ondersteuning &amp; PRO functies."
+
+#: pro/acf-pro.php:169
+msgid ""
+"Activate your license to enable access to updates, support &amp; PRO "
+"features."
+msgstr ""
+"Activeer uw licentie om toegang te krijgen tot updates, ondersteuning &amp; "
+"PRO functies."
+
+#: pro/acf-pro.php:190, pro/admin/views/html-settings-updates.php:114
+msgid "Manage License"
+msgstr "Licentie beheren"
+
+#: pro/acf-pro.php:258
+msgid "A valid license is required to edit options pages."
+msgstr "U heeft een geldige licentie nodig om opties pagina's te bewerken."
+
+#: pro/acf-pro.php:256
+msgid "A valid license is required to edit field groups assigned to a block."
+msgstr ""
+"U heeft een geldige licentie nodig om veldgroepen, die aan een blok zijn "
+"toegewezen, te bewerken."
+
+#: pro/blocks.php:186
+msgid "Block type name is required."
+msgstr "De naam van het bloktype is verplicht."
+
+#. translators: The name of the block type
+#: pro/blocks.php:194
+msgid "Block type \"%s\" is already registered."
+msgstr "Bloktype “%s” is al geregistreerd."
+
+#: pro/blocks.php:740
+msgid "The render template for this ACF Block was not found"
+msgstr "De rendertemplate voor dit ACF blok is niet gevonden"
+
+#: pro/blocks.php:790
+msgid "Switch to Edit"
+msgstr "Schakel naar bewerken"
+
+#: pro/blocks.php:791
+msgid "Switch to Preview"
+msgstr "Schakel naar voorbeeld"
+
+#: pro/blocks.php:792
+msgid "Change content alignment"
+msgstr "Inhoudsuitlijning wijzigen"
+
+#: pro/blocks.php:793
+msgid "An error occurred when loading the preview for this block."
+msgstr ""
+"Er is een fout opgetreden bij het laden van het voorbeeld voor dit blok."
+
+#: pro/blocks.php:794
+msgid "An error occurred when loading the block in edit mode."
+msgstr ""
+"Er is een fout opgetreden bij het laden van het blok in bewerkingsmodus."
+
+#. translators: %s: Block type title
+#: pro/blocks.php:797
+msgid "%s settings"
+msgstr "%s instellingen"
+
+#: pro/blocks.php:1039
+msgid "This block contains no editable fields."
+msgstr "Dit blok bevat geen bewerkbare velden."
+
+#. translators: %s: an admin URL to the field group edit screen
+#: pro/blocks.php:1045
+msgid ""
+"Assign a <a href=\"%s\" target=\"_blank\">field group</a> to add fields to "
+"this block."
+msgstr ""
+"Wijs een <a href=“%s” target=“_blank”>veldgroep</a> toe om velden aan dit "
+"blok toe te voegen."
+
+#: pro/options-page.php:43,
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:237
+msgid "Options"
+msgstr "Opties"
+
+#: pro/options-page.php:73, pro/fields/class-acf-field-gallery.php:483,
+#: pro/post-types/acf-ui-options-page.php:173,
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:165
+msgid "Update"
+msgstr "Updaten"
+
+#: pro/options-page.php:74, pro/post-types/acf-ui-options-page.php:174
+msgid "Options Updated"
+msgstr "Opties geüpdatet"
+
+#. translators: %1 A link to the updates page. %2 link to the pricing page
+#: pro/updates.php:75
+msgid ""
+"To enable updates, please enter your license key on the <a "
+"href=\"%1$s\">Updates</a> page. If you don't have a license key, please see "
+"<a href=\"%2$s\" target=\"_blank\">details & pricing</a>."
+msgstr ""
+"Om updates te ontvangen, vult u hieronder uw licentiecode in. Als u geen "
+"licentiesleutel hebt, raadpleeg dan <a href=“%2$s” target=“_blank”>details & "
+"prijzen</a>."
+
+#: pro/updates.php:71
+msgid ""
+"To enable updates, please enter your license key on the <a "
+"href=\"%1$s\">Updates</a> page of the main site. If you don't have a license "
+"key, please see <a href=\"%2$s\" target=\"_blank\">details & pricing</a>."
+msgstr ""
+"Om updates in te schakelen, voert u uw licentiesleutel in op de <a "
+"href=\"%1$s\">Updates</a> pagina van de hoofdsite. Als u geen "
+"licentiesleutel hebt, raadpleeg dan <a href=“%2$s” target=“_blank”>details & "
+"prijzen</a>."
+
+#: pro/updates.php:136
+msgid ""
+"Your defined license key has changed, but an error occurred when "
+"deactivating your old license"
+msgstr ""
+"Uw gedefinieerde licentiesleutel is gewijzigd, maar er is een fout "
+"opgetreden bij het deactiveren van uw oude licentie"
+
+#: pro/updates.php:133
+msgid ""
+"Your defined license key has changed, but an error occurred when connecting "
+"to activation server"
+msgstr ""
+"Uw gedefinieerde licentiesleutel is gewijzigd, maar er is een fout "
+"opgetreden bij het verbinden met de activeringsserver"
+
+#: pro/updates.php:168
+msgid ""
+"<strong>ACF PRO &mdash;</strong> Your license key has been activated "
+"successfully. Access to updates, support &amp; PRO features is now enabled."
+msgstr ""
+"<strong>ACF PRO &mdash;</strong> Uw licentiesleutel is succesvol "
+"geactiveerd. Toegang tot updates, ondersteuning &amp; PRO functies is nu "
+"ingeschakeld."
+
+#: pro/updates.php:159
+msgid "There was an issue activating your license key."
+msgstr ""
+"Er is een probleem opgetreden bij het activeren van uw licentiesleutel."
+
+#: pro/updates.php:155
+msgid "An error occurred when connecting to activation server"
+msgstr "Er is een fout opgetreden bij het verbinden met de activeringsserver"
+
+#: pro/updates.php:258
+msgid ""
+"The ACF activation service is temporarily unavailable. Please try again "
+"later."
+msgstr ""
+"De ACF activeringsservice is tijdelijk niet beschikbaar. Probeer het later "
+"nog eens."
+
+#: pro/updates.php:256
+msgid ""
+"The ACF activation service is temporarily unavailable for scheduled "
+"maintenance. Please try again later."
+msgstr ""
+"De ACF activeringsservice is tijdelijk niet beschikbaar voor gepland "
+"onderhoud. Probeer het later nog eens."
+
+#: pro/updates.php:254
+msgid ""
+"An upstream API error occurred when checking your ACF PRO license status. We "
+"will retry again shortly."
+msgstr ""
+"Er is een API fout opgetreden bij het controleren van uw ACF PRO "
+"licentiestatus. We zullen het binnenkort opnieuw proberen."
+
+#: pro/updates.php:224
+msgid "You have reached the activation limit for the license."
+msgstr "U heeft de activeringslimiet voor de licentie bereikt."
+
+#: pro/updates.php:233, pro/updates.php:205
+msgid "View your licenses"
+msgstr "Uw licenties bekijken"
+
+#: pro/updates.php:246
+msgid "check again"
+msgstr "opnieuw controleren"
+
+#: pro/updates.php:250
+msgid "%1$s or %2$s."
+msgstr "%1$s of %2$s."
+
+#: pro/updates.php:210
+msgid "Your license key has expired and cannot be activated."
+msgstr "Uw licentiesleutel is verlopen en kan niet worden geactiveerd."
+
+#: pro/updates.php:219
+msgid "View your subscriptions"
+msgstr "Uw abonnementen bekijken"
+
+#: pro/updates.php:196
+msgid ""
+"License key not found. Make sure you have copied your license key exactly as "
+"it appears in your receipt or your account."
+msgstr ""
+"Licentiesleutel niet gevonden. Zorg ervoor dat u de licentiesleutel precies "
+"zo hebt gekopieerd als op uw ontvangstbewijs of in je account."
+
+#: pro/updates.php:194
+msgid "Your license key has been deactivated."
+msgstr "Uw licentiesleutel is gedeactiveerd."
+
+#: pro/updates.php:192
+msgid ""
+"Your license key has been activated successfully. Access to updates, support "
+"&amp; PRO features is now enabled."
+msgstr ""
+"Uw licentiesleutel is succesvol geactiveerd. Toegang tot updates, "
+"ondersteuning &amp; PRO functies is nu ingeschakeld."
+
+#. translators: %s an untranslatable internal upstream error message
+#: pro/updates.php:262
+msgid ""
+"An unknown error occurred while trying to communicate with the ACF "
+"activation service: %s."
+msgstr ""
+"Er is een onbekende fout opgetreden tijdens het communiceren met de ACF "
+"activeringsservice: %s."
+
+#: pro/updates.php:333, pro/updates.php:975
+msgid "<strong>ACF PRO &mdash;</strong>"
+msgstr "<strong>ACF PRO &mdash;</strong>"
+
+#: pro/updates.php:342
+msgid "Check again"
+msgstr "Opnieuw controleren"
+
+#: pro/updates.php:683
+msgid "Could not connect to the activation server"
+msgstr "Kon niet verbinden met de activeringsserver"
+
+#. translators: %s - URL to ACF updates page
+#: pro/updates.php:753
+msgid ""
+"Your license key is valid but not activated on this site. Please <a "
+"href=\"%s\">deactivate</a> and then reactivate the license."
+msgstr ""
+"Uw licentiesleutel is geldig maar niet geactiveerd op deze site. <a "
+"href=\"%s\">Deactiveer</a> de licentie en activeer deze opnieuw."
+
+#: pro/updates.php:975
+msgid ""
+"Your site URL has changed since last activating your license. We've "
+"automatically activated it for this site URL."
+msgstr ""
+"De URL van uw site is veranderd sinds de laatste keer dat u uw licentie hebt "
+"geactiveerd. We hebben het automatisch geactiveerd voor deze site URL."
+
+#: pro/updates.php:967
+msgid ""
+"Your site URL has changed since last activating your license, but we weren't "
+"able to automatically reactivate it: %s"
+msgstr ""
+"De URL van uw site is veranderd sinds de laatste keer dat u uw licentie hebt "
+"geactiveerd, maar we hebben hem niet automatisch opnieuw kunnen activeren: %s"
+
+#: pro/admin/admin-options-page.php:159
+msgid "Publish"
+msgstr "Publiceren"
+
+#: pro/admin/admin-options-page.php:162
+msgid ""
+"No Custom Field Groups found for this options page. <a href=\"%s\">Create a "
+"Custom Field Group</a>"
+msgstr ""
+"Er zijn geen groepen gevonden voor deze opties pagina. <a href=\"%s\">Maak "
+"een extra veldgroep</a>"
+
+#: pro/admin/admin-options-page.php:258
+msgid "Edit field group"
+msgstr "Veldgroep bewerken"
+
+#: pro/admin/admin-updates.php:52
+msgid "<strong>Error</strong>. Could not connect to the update server"
+msgstr "<b>Fout</b>. Kon niet verbinden met de updateserver"
+
+#: pro/admin/admin-updates.php:117,
+#: pro/admin/views/html-settings-updates.php:132
+msgid "Updates"
+msgstr "Updates"
+
+#. translators: %s the version of WordPress required for this ACF update
+#: pro/admin/admin-updates.php:203
+msgid ""
+"An update to ACF is available, but it is not compatible with your version of "
+"WordPress. Please upgrade to WordPress %s or newer to update ACF."
+msgstr ""
+"Er is een update voor ACF beschikbaar, maar deze is niet compatibel met uw "
+"versie van WordPress. Upgrade naar WordPress %s of nieuwer om ACF te updaten."
+
+#: pro/admin/admin-updates.php:224
+msgid ""
+"<strong>Error</strong>. Could not authenticate update package. Please check "
+"again or deactivate and reactivate your ACF PRO license."
+msgstr ""
+"<strong>Fout</strong>. Kan het updatepakket niet verifiëren. Controleer "
+"opnieuw of deactiveer en heractiveer uw ACF PRO licentie."
+
+#: pro/admin/admin-updates.php:214
+msgid ""
+"<strong>Error</strong>. Your license for this site has expired or been "
+"deactivated. Please reactivate your ACF PRO license."
+msgstr ""
+"<strong>Fout</strong>. Uw licentie voor deze site is verlopen of "
+"gedeactiveerd. Activeer uw ACF PRO licentie opnieuw."
+
+#: pro/fields/class-acf-field-clone.php:22
+msgctxt "noun"
+msgid "Clone"
+msgstr "Klonen"
+
+#: pro/fields/class-acf-field-clone.php:24
+msgid ""
+"Allows you to select and display existing fields. It does not duplicate any "
+"fields in the database, but loads and displays the selected fields at run-"
+"time. The Clone field can either replace itself with the selected fields or "
+"display the selected fields as a group of subfields."
+msgstr ""
+"Hiermee kunt u bestaande velden selecteren en weergeven. Het dupliceert geen "
+"velden in de database, maar laadt en toont de geselecteerde velden bij run-"
+"time. Het kloonveld kan zichzelf vervangen door de geselecteerde velden of "
+"de geselecteerde velden weergeven als een groep subvelden."
+
+#: pro/fields/class-acf-field-clone.php:724,
+#: pro/fields/class-acf-field-flexible-content.php:72
+msgid "Fields"
+msgstr "Velden"
+
+#: pro/fields/class-acf-field-clone.php:725
+msgid "Select one or more fields you wish to clone"
+msgstr "Selecteer één of meer velden om te klonen"
+
+#: pro/fields/class-acf-field-clone.php:745
+msgid "Display"
+msgstr "Weergeven"
+
+#: pro/fields/class-acf-field-clone.php:746
+msgid "Specify the style used to render the clone field"
+msgstr "Kies de gebruikte stijl bij het renderen van het gekloonde veld"
+
+#: pro/fields/class-acf-field-clone.php:751
+msgid "Group (displays selected fields in a group within this field)"
+msgstr "Groep (toont geselecteerde velden in een groep binnen dit veld)"
+
+#: pro/fields/class-acf-field-clone.php:752
+msgid "Seamless (replaces this field with selected fields)"
+msgstr "Naadloos (vervangt dit veld met de geselecteerde velden)"
+
+#: pro/fields/class-acf-field-clone.php:761,
+#: pro/fields/class-acf-field-flexible-content.php:509,
+#: pro/fields/class-acf-field-flexible-content.php:572,
+#: pro/fields/class-acf-field-repeater.php:178
+msgid "Layout"
+msgstr "Lay-out"
+
+#: pro/fields/class-acf-field-clone.php:762
+msgid "Specify the style used to render the selected fields"
+msgstr "Kies de gebruikte stijl bij het renderen van de geselecteerde velden"
+
+#: pro/fields/class-acf-field-clone.php:767,
+#: pro/fields/class-acf-field-flexible-content.php:585,
+#: pro/fields/class-acf-field-repeater.php:186,
+#: pro/locations/class-acf-location-block.php:22
+msgid "Block"
+msgstr "Blok"
+
+#: pro/fields/class-acf-field-clone.php:768,
+#: pro/fields/class-acf-field-flexible-content.php:584,
+#: pro/fields/class-acf-field-repeater.php:185
+msgid "Table"
+msgstr "Tabel"
+
+#: pro/fields/class-acf-field-clone.php:769,
+#: pro/fields/class-acf-field-flexible-content.php:586,
+#: pro/fields/class-acf-field-repeater.php:187
+msgid "Row"
+msgstr "Rij"
+
+#: pro/fields/class-acf-field-clone.php:775
+msgid "Labels will be displayed as %s"
+msgstr "Labels worden weergegeven als %s"
+
+#: pro/fields/class-acf-field-clone.php:780
+msgid "Prefix Field Labels"
+msgstr "Prefix veld labels"
+
+#: pro/fields/class-acf-field-clone.php:790
+msgid "Values will be saved as %s"
+msgstr "Waarden worden opgeslagen als %s"
+
+#: pro/fields/class-acf-field-clone.php:795
+msgid "Prefix Field Names"
+msgstr "Prefix veld namen"
+
+#: pro/fields/class-acf-field-clone.php:892
+msgid "Unknown field"
+msgstr "Onbekend veld"
+
+#: pro/fields/class-acf-field-clone.php:896
+msgid "(no title)"
+msgstr "(geen titel)"
+
+#: pro/fields/class-acf-field-clone.php:925
+msgid "Unknown field group"
+msgstr "Onbekend groep"
+
+#: pro/fields/class-acf-field-clone.php:929
+msgid "All fields from %s field group"
+msgstr "Alle velden van %s veldgroep"
+
+#: pro/fields/class-acf-field-flexible-content.php:22
+msgid "Flexible Content"
+msgstr "Flexibele inhoud"
+
+#: pro/fields/class-acf-field-flexible-content.php:24
+msgid ""
+"Allows you to define, create and manage content with total control by "
+"creating layouts that contain subfields that content editors can choose from."
+msgstr ""
+"Hiermee kunt u inhoud definiëren, creëren en beheren met volledige controle "
+"door lay-outs te maken die subvelden bevatten waaruit inhoudsredacteuren "
+"kunnen kiezen."
+
+#: pro/fields/class-acf-field-flexible-content.php:24
+msgid "We do not recommend using this field in ACF Blocks."
+msgstr "Wij raden het gebruik van dit veld in ACF blokken af."
+
+#: pro/fields/class-acf-field-flexible-content.php:34,
+#: pro/fields/class-acf-field-repeater.php:104,
+#: pro/fields/class-acf-field-repeater.php:298
+msgid "Add Row"
+msgstr "Nieuwe rij"
+
+#: pro/fields/class-acf-field-flexible-content.php:70,
+#: pro/fields/class-acf-field-flexible-content.php:867,
+#: pro/fields/class-acf-field-flexible-content.php:949
+msgid "layout"
+msgid_plural "layouts"
+msgstr[0] "lay-out"
+msgstr[1] "lay-outs"
+
+#: pro/fields/class-acf-field-flexible-content.php:71
+msgid "layouts"
+msgstr "lay-outs"
+
+#: pro/fields/class-acf-field-flexible-content.php:75,
+#: pro/fields/class-acf-field-flexible-content.php:866,
+#: pro/fields/class-acf-field-flexible-content.php:948
+msgid "This field requires at least {min} {label} {identifier}"
+msgstr "Dit veld vereist op zijn minst {min} {label} {identifier}"
+
+#: pro/fields/class-acf-field-flexible-content.php:76
+msgid "This field has a limit of {max} {label} {identifier}"
+msgstr "Dit veld heeft een limiet van {max} {label} {identifier}"
+
+#: pro/fields/class-acf-field-flexible-content.php:79
+msgid "{available} {label} {identifier} available (max {max})"
+msgstr "{available} {label} {identifier} beschikbaar (max {max})"
+
+#: pro/fields/class-acf-field-flexible-content.php:80
+msgid "{required} {label} {identifier} required (min {min})"
+msgstr "{required} {label} {identifier} verplicht (min {min})"
+
+#: pro/fields/class-acf-field-flexible-content.php:83
+msgid "Flexible Content requires at least 1 layout"
+msgstr "Flexibele inhoud vereist minimaal 1 lay-out"
+
+#. translators: %s the button label used for adding a new layout.
+#: pro/fields/class-acf-field-flexible-content.php:255
+msgid "Click the \"%s\" button below to start creating your layout"
+msgstr "Klik op de \"%s\" knop om een nieuwe lay-out te maken"
+
+#: pro/fields/class-acf-field-flexible-content.php:375,
+#: pro/fields/class-acf-repeater-table.php:364
+msgid "Drag to reorder"
+msgstr "Slepen om te herschikken"
+
+#: pro/fields/class-acf-field-flexible-content.php:378
+msgid "Add layout"
+msgstr "Lay-out toevoegen"
+
+#: pro/fields/class-acf-field-flexible-content.php:379
+msgid "Duplicate layout"
+msgstr "Lay-out dupliceren"
+
+#: pro/fields/class-acf-field-flexible-content.php:380
+msgid "Remove layout"
+msgstr "Lay-out verwijderen"
+
+#: pro/fields/class-acf-field-flexible-content.php:381,
+#: pro/fields/class-acf-repeater-table.php:380
+msgid "Click to toggle"
+msgstr "Klik om in/uit te klappen"
+
+#: pro/fields/class-acf-field-flexible-content.php:517
+msgid "Delete Layout"
+msgstr "Lay-out verwijderen"
+
+#: pro/fields/class-acf-field-flexible-content.php:518
+msgid "Duplicate Layout"
+msgstr "Lay-out dupliceren"
+
+#: pro/fields/class-acf-field-flexible-content.php:519
+msgid "Add New Layout"
+msgstr "Nieuwe layout"
+
+#: pro/fields/class-acf-field-flexible-content.php:519
+msgid "Add Layout"
+msgstr "Lay-out toevoegen"
+
+#: pro/fields/class-acf-field-flexible-content.php:548
+msgid "Label"
+msgstr "Label"
+
+#: pro/fields/class-acf-field-flexible-content.php:565
+msgid "Name"
+msgstr "Naam"
+
+#: pro/fields/class-acf-field-flexible-content.php:603
+msgid "Min"
+msgstr "Min"
+
+#: pro/fields/class-acf-field-flexible-content.php:618
+msgid "Max"
+msgstr "Max"
+
+#: pro/fields/class-acf-field-flexible-content.php:659
+msgid "Minimum Layouts"
+msgstr "Minimale layouts"
+
+#: pro/fields/class-acf-field-flexible-content.php:670
+msgid "Maximum Layouts"
+msgstr "Maximale lay-outs"
+
+#: pro/fields/class-acf-field-flexible-content.php:681,
+#: pro/fields/class-acf-field-repeater.php:294
+msgid "Button Label"
+msgstr "Knop label"
+
+#: pro/fields/class-acf-field-flexible-content.php:1552,
+#: pro/fields/class-acf-field-repeater.php:913
+msgid "%s must be of type array or null."
+msgstr "%s moet van het type array of null zijn."
+
+#: pro/fields/class-acf-field-flexible-content.php:1563
+msgid "%1$s must contain at least %2$s %3$s layout."
+msgid_plural "%1$s must contain at least %2$s %3$s layouts."
+msgstr[0] "%1$s moet minstens %2$s %3$s lay-out bevatten."
+msgstr[1] "%1$s moet minstens %2$s %3$s lay-outs bevatten."
+
+#: pro/fields/class-acf-field-flexible-content.php:1579
+msgid "%1$s must contain at most %2$s %3$s layout."
+msgid_plural "%1$s must contain at most %2$s %3$s layouts."
+msgstr[0] "%1$s moet hoogstens %2$s %3$s lay-out bevatten."
+msgstr[1] "%1$s moet hoogstens %2$s %3$s lay-outs bevatten."
+
+#: pro/fields/class-acf-field-gallery.php:22
+msgid "Gallery"
+msgstr "Galerij"
+
+#: pro/fields/class-acf-field-gallery.php:24
+msgid ""
+"An interactive interface for managing a collection of attachments, such as "
+"images."
+msgstr ""
+"Een interactieve interface voor het beheer van een verzameling van bijlagen, "
+"zoals afbeeldingen."
+
+#: pro/fields/class-acf-field-gallery.php:72
+msgid "Add Image to Gallery"
+msgstr "Afbeelding toevoegen aan galerij"
+
+#: pro/fields/class-acf-field-gallery.php:73
+msgid "Maximum selection reached"
+msgstr "Maximale selectie bereikt"
+
+#: pro/fields/class-acf-field-gallery.php:282
+msgid "Length"
+msgstr "Lengte"
+
+#: pro/fields/class-acf-field-gallery.php:297
+msgid "Edit"
+msgstr "Bewerken"
+
+#: pro/fields/class-acf-field-gallery.php:298,
+#: pro/fields/class-acf-field-gallery.php:451
+msgid "Remove"
+msgstr "Verwijderen"
+
+#: pro/fields/class-acf-field-gallery.php:314
+msgid "Title"
+msgstr "Titel"
+
+#: pro/fields/class-acf-field-gallery.php:326
+msgid "Caption"
+msgstr "Onderschrift"
+
+#: pro/fields/class-acf-field-gallery.php:338
+msgid "Alt Text"
+msgstr "Alt tekst"
+
+#: pro/fields/class-acf-field-gallery.php:350,
+#: pro/admin/post-types/admin-ui-options-pages.php:117,
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:153
+msgid "Description"
+msgstr "Omschrijving"
+
+#: pro/fields/class-acf-field-gallery.php:460
+msgid "Add to gallery"
+msgstr "Afbeelding(en) toevoegen"
+
+#: pro/fields/class-acf-field-gallery.php:464
+msgid "Bulk actions"
+msgstr "Bulkacties"
+
+#: pro/fields/class-acf-field-gallery.php:465
+msgid "Sort by date uploaded"
+msgstr "Sorteren op datum geüpload"
+
+#: pro/fields/class-acf-field-gallery.php:466
+msgid "Sort by date modified"
+msgstr "Sorteren op datum aangepast"
+
+#: pro/fields/class-acf-field-gallery.php:467
+msgid "Sort by title"
+msgstr "Sorteren op titel"
+
+#: pro/fields/class-acf-field-gallery.php:468
+msgid "Reverse current order"
+msgstr "Volgorde omkeren"
+
+#: pro/fields/class-acf-field-gallery.php:480
+msgid "Close"
+msgstr "Sluiten"
+
+#: pro/fields/class-acf-field-gallery.php:508
+msgid "Return Format"
+msgstr "Output weergeven als"
+
+#: pro/fields/class-acf-field-gallery.php:514
+msgid "Image Array"
+msgstr "Afbeelding array"
+
+#: pro/fields/class-acf-field-gallery.php:515
+msgid "Image URL"
+msgstr "Afbeelding URL"
+
+#: pro/fields/class-acf-field-gallery.php:516
+msgid "Image ID"
+msgstr "Afbeelding ID"
+
+#: pro/fields/class-acf-field-gallery.php:524
+msgid "Library"
+msgstr "Bibliotheek"
+
+#: pro/fields/class-acf-field-gallery.php:525
+msgid "Limit the media library choice"
+msgstr "Mediabibliotheek keuze beperken"
+
+#: pro/fields/class-acf-field-gallery.php:530,
+#: pro/locations/class-acf-location-block.php:68
+msgid "All"
+msgstr "Alles"
+
+#: pro/fields/class-acf-field-gallery.php:531
+msgid "Uploaded to post"
+msgstr "Geüpload naar bericht"
+
+#: pro/fields/class-acf-field-gallery.php:567
+msgid "Minimum Selection"
+msgstr "Minimale selectie"
+
+#: pro/fields/class-acf-field-gallery.php:577
+msgid "Maximum Selection"
+msgstr "Maximale selectie"
+
+#: pro/fields/class-acf-field-gallery.php:587
+msgid "Minimum"
+msgstr "Minimaal"
+
+#: pro/fields/class-acf-field-gallery.php:588,
+#: pro/fields/class-acf-field-gallery.php:624
+msgid "Restrict which images can be uploaded"
+msgstr "Bepaal welke afbeeldingen geüpload mogen worden"
+
+#: pro/fields/class-acf-field-gallery.php:591,
+#: pro/fields/class-acf-field-gallery.php:627
+msgid "Width"
+msgstr "Breedte"
+
+#: pro/fields/class-acf-field-gallery.php:602,
+#: pro/fields/class-acf-field-gallery.php:638
+msgid "Height"
+msgstr "Hoogte"
+
+#: pro/fields/class-acf-field-gallery.php:614,
+#: pro/fields/class-acf-field-gallery.php:650
+msgid "File size"
+msgstr "Bestandsgrootte"
+
+#: pro/fields/class-acf-field-gallery.php:623
+msgid "Maximum"
+msgstr "Maximaal"
+
+#: pro/fields/class-acf-field-gallery.php:659
+msgid "Allowed File Types"
+msgstr "Toegestane bestandstypen"
+
+#: pro/fields/class-acf-field-gallery.php:660
+msgid "Comma separated list. Leave blank for all types"
+msgstr "Met komma's gescheiden lijst. Laat leeg voor alle types"
+
+#: pro/fields/class-acf-field-gallery.php:679
+msgid "Insert"
+msgstr "Invoegen"
+
+#: pro/fields/class-acf-field-gallery.php:680
+msgid "Specify where new attachments are added"
+msgstr "Geef aan waar nieuwe bijlagen worden toegevoegd"
+
+#: pro/fields/class-acf-field-gallery.php:684
+msgid "Append to the end"
+msgstr "Toevoegen aan het einde"
+
+#: pro/fields/class-acf-field-gallery.php:685
+msgid "Prepend to the beginning"
+msgstr "Toevoegen aan het begin"
+
+#: pro/fields/class-acf-field-gallery.php:693
+msgid "Preview Size"
+msgstr "Voorbeeldgrootte"
+
+#: pro/fields/class-acf-field-gallery.php:787
+msgid "%1$s requires at least %2$s selection"
+msgid_plural "%1$s requires at least %2$s selections"
+msgstr[0] "%1$s vereist minstens %2$s selectie"
+msgstr[1] "%1$s vereist minstens %2$s selecties"
+
+#: pro/fields/class-acf-field-repeater.php:29
+msgid "Repeater"
+msgstr "Herhalen"
+
+#: pro/fields/class-acf-field-repeater.php:31
+msgid ""
+"Provides a solution for repeating content such as slides, team members, and "
+"call-to-action tiles, by acting as a parent to a set of subfields which can "
+"be repeated again and again."
+msgstr ""
+"Dit biedt een oplossing voor herhalende inhoud zoals slides, teamleden en "
+"call-to-action tegels, door te dienen als een hoofditem voor een set "
+"subvelden die steeds opnieuw kunnen worden herhaald."
+
+#: pro/fields/class-acf-field-repeater.php:67,
+#: pro/fields/class-acf-field-repeater.php:462
+msgid "Minimum rows not reached ({min} rows)"
+msgstr "Minimum aantal rijen bereikt ({min} rijen)"
+
+#: pro/fields/class-acf-field-repeater.php:68
+msgid "Maximum rows reached ({max} rows)"
+msgstr "Maximum aantal rijen bereikt ({max} rijen)"
+
+#: pro/fields/class-acf-field-repeater.php:69
+msgid "Error loading page"
+msgstr "Fout bij het laden van de pagina"
+
+#: pro/fields/class-acf-field-repeater.php:70
+msgid "Order will be assigned upon save"
+msgstr "Volgorde zal worden toegewezen bij opslaan"
+
+#: pro/fields/class-acf-field-repeater.php:163
+msgid "Sub Fields"
+msgstr "Subvelden"
+
+#: pro/fields/class-acf-field-repeater.php:196
+msgid "Pagination"
+msgstr "Paginering"
+
+#: pro/fields/class-acf-field-repeater.php:197
+msgid "Useful for fields with a large number of rows."
+msgstr "Nuttig voor velden met een groot aantal rijen."
+
+#: pro/fields/class-acf-field-repeater.php:208
+msgid "Rows Per Page"
+msgstr "Rijen per pagina"
+
+#: pro/fields/class-acf-field-repeater.php:209
+msgid "Set the number of rows to be displayed on a page."
+msgstr "Stel het aantal rijen in om weer te geven op een pagina."
+
+#: pro/fields/class-acf-field-repeater.php:241
+msgid "Minimum Rows"
+msgstr "Minimum aantal rijen"
+
+#: pro/fields/class-acf-field-repeater.php:252
+msgid "Maximum Rows"
+msgstr "Maximum aantal rijen"
+
+#: pro/fields/class-acf-field-repeater.php:282
+msgid "Collapsed"
+msgstr "Ingeklapt"
+
+#: pro/fields/class-acf-field-repeater.php:283
+msgid "Select a sub field to show when row is collapsed"
+msgstr "Selecteer een subveld om weer te geven wanneer rij dichtgeklapt is"
+
+#: pro/fields/class-acf-field-repeater.php:1050
+msgid "Invalid nonce."
+msgstr "Ongeldige nonce."
+
+#: pro/fields/class-acf-field-repeater.php:1055
+msgid "Invalid field key or name."
+msgstr "Ongeldige veldsleutel of -naam."
+
+#: pro/fields/class-acf-field-repeater.php:1064
+msgid "There was an error retrieving the field."
+msgstr "Er is een fout opgetreden bij het ophalen van het veld."
+
+#: pro/fields/class-acf-repeater-table.php:367
+msgid "Click to reorder"
+msgstr "Klik om te herschikken"
+
+#: pro/fields/class-acf-repeater-table.php:400
+msgid "Add row"
+msgstr "Nieuwe rij"
+
+#: pro/fields/class-acf-repeater-table.php:401
+msgid "Duplicate row"
+msgstr "Rij dupliceren"
+
+#: pro/fields/class-acf-repeater-table.php:402
+msgid "Remove row"
+msgstr "Regel verwijderen"
+
+#: pro/fields/class-acf-repeater-table.php:446,
+#: pro/fields/class-acf-repeater-table.php:463,
+#: pro/fields/class-acf-repeater-table.php:464
+msgid "Current Page"
+msgstr "Huidige pagina"
+
+#: pro/fields/class-acf-repeater-table.php:454,
+#: pro/fields/class-acf-repeater-table.php:455
+msgid "First Page"
+msgstr "Eerste pagina"
+
+#: pro/fields/class-acf-repeater-table.php:458,
+#: pro/fields/class-acf-repeater-table.php:459
+msgid "Previous Page"
+msgstr "Vorige pagina"
+
+#. translators: 1: Current page, 2: Total pages.
+#: pro/fields/class-acf-repeater-table.php:468
+msgctxt "paging"
+msgid "%1$s of %2$s"
+msgstr "%1$s van %2$s"
+
+#: pro/fields/class-acf-repeater-table.php:475,
+#: pro/fields/class-acf-repeater-table.php:476
+msgid "Next Page"
+msgstr "Volgende pagina"
+
+#: pro/fields/class-acf-repeater-table.php:479,
+#: pro/fields/class-acf-repeater-table.php:480
+msgid "Last Page"
+msgstr "Laatste pagina"
+
+#: pro/locations/class-acf-location-block.php:73
+msgid "No block types exist"
+msgstr "Er bestaan geen bloktypes"
+
+#: pro/locations/class-acf-location-options-page.php:22
+msgid "Options Page"
+msgstr "Opties pagina"
+
+#: pro/locations/class-acf-location-options-page.php:70
+msgid "Select options page..."
+msgstr "Opties pagina selecteren…"
+
+#: pro/locations/class-acf-location-options-page.php:74,
+#: pro/post-types/acf-ui-options-page.php:95,
+#: pro/admin/post-types/admin-ui-options-page.php:482
+msgid "Add New Options Page"
+msgstr "Nieuwe opties pagina toevoegen"
+
+#: pro/post-types/acf-ui-options-page.php:92,
+#: pro/post-types/acf-ui-options-page.php:93,
+#: pro/admin/post-types/admin-ui-options-pages.php:94,
+#: pro/admin/post-types/admin-ui-options-pages.php:94
+msgid "Options Pages"
+msgstr "Opties pagina’s"
+
+#: pro/post-types/acf-ui-options-page.php:94
+msgid "Add New"
+msgstr "Nieuwe toevoegen"
+
+#: pro/post-types/acf-ui-options-page.php:96
+msgid "Edit Options Page"
+msgstr "Opties pagina bewerken"
+
+#: pro/post-types/acf-ui-options-page.php:97
+msgid "New Options Page"
+msgstr "Nieuwe opties pagina"
+
+#: pro/post-types/acf-ui-options-page.php:98
+msgid "View Options Page"
+msgstr "Opties pagina bekijken"
+
+#: pro/post-types/acf-ui-options-page.php:99
+msgid "Search Options Pages"
+msgstr "Opties pagina’s zoeken"
+
+#: pro/post-types/acf-ui-options-page.php:100
+msgid "No Options Pages found"
+msgstr "Geen opties pagina’s gevonden"
+
+#: pro/post-types/acf-ui-options-page.php:101
+msgid "No Options Pages found in Trash"
+msgstr "Geen opties pagina’s gevonden in prullenbak"
+
+#: pro/post-types/acf-ui-options-page.php:203
+msgid ""
+"The menu slug must only contain lower case alphanumeric characters, "
+"underscores or dashes."
+msgstr ""
+"De menuslug mag alleen kleine alfanumerieke tekens, underscores of streepjes "
+"bevatten."
+
+#: pro/post-types/acf-ui-options-page.php:235
+msgid "This Menu Slug is already in use by another ACF Options Page."
+msgstr "Deze menuslug wordt al gebruikt door een andere ACF opties pagina."
+
+#: pro/admin/post-types/admin-ui-options-page.php:56
+msgid "Options page deleted."
+msgstr "Opties pagina verwijderd."
+
+#: pro/admin/post-types/admin-ui-options-page.php:57
+msgid "Options page updated."
+msgstr "Opties pagina geüpdatet."
+
+#: pro/admin/post-types/admin-ui-options-page.php:60
+msgid "Options page saved."
+msgstr "Opties pagina opgeslagen."
+
+#: pro/admin/post-types/admin-ui-options-page.php:61
+msgid "Options page submitted."
+msgstr "Opties pagina ingediend."
+
+#: pro/admin/post-types/admin-ui-options-page.php:62
+msgid "Options page scheduled for."
+msgstr "Opties pagina gepland voor."
+
+#: pro/admin/post-types/admin-ui-options-page.php:63
+msgid "Options page draft updated."
+msgstr "Opties pagina concept geüpdatet."
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:83
+msgid "%s options page updated"
+msgstr "%s opties pagina geüpdatet"
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:85
+msgid "Add fields to %s"
+msgstr "Velden toevoegen aan %s"
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:89
+msgid "%s options page created"
+msgstr "%s opties pagina aangemaakt"
+
+#: pro/admin/post-types/admin-ui-options-page.php:102
+msgid "Link existing field groups"
+msgstr "Koppel bestaande veldgroepen"
+
+#: pro/admin/post-types/admin-ui-options-page.php:131
+msgid "Post"
+msgstr "Bericht"
+
+#: pro/admin/post-types/admin-ui-options-page.php:132
+msgid "Posts"
+msgstr "Berichten"
+
+#: pro/admin/post-types/admin-ui-options-page.php:133
+msgid "Page"
+msgstr "Pagina"
+
+#: pro/admin/post-types/admin-ui-options-page.php:134
+msgid "Pages"
+msgstr "Pagina’s"
+
+#: pro/admin/post-types/admin-ui-options-page.php:135
+msgid "Default"
+msgstr "Standaard"
+
+#: pro/admin/post-types/admin-ui-options-page.php:157
+msgid "Basic Settings"
+msgstr "Basis instellingen"
+
+#: pro/admin/post-types/admin-ui-options-page.php:158
+msgid "Advanced Settings"
+msgstr "Geavanceerde instellingen"
+
+#: pro/admin/post-types/admin-ui-options-page.php:283
+msgctxt "post status"
+msgid "Active"
+msgstr "Actief"
+
+#: pro/admin/post-types/admin-ui-options-page.php:283
+msgctxt "post status"
+msgid "Inactive"
+msgstr "Inactief"
+
+#: pro/admin/post-types/admin-ui-options-page.php:361
+msgid "No Parent"
+msgstr "Geen hoofditem"
+
+#: pro/admin/post-types/admin-ui-options-page.php:450
+msgid "The provided Menu Slug already exists."
+msgstr "De opgegeven menuslug bestaat al."
+
+#: pro/admin/post-types/admin-ui-options-pages.php:118
+msgid "Key"
+msgstr "Sleutel"
+
+#: pro/admin/post-types/admin-ui-options-pages.php:122
+msgid "Local JSON"
+msgstr "Lokale JSON"
+
+#: pro/admin/post-types/admin-ui-options-pages.php:151
+msgid "No description"
+msgstr "Geen beschrijving"
+
+#. translators: %s number of post types activated
+#: pro/admin/post-types/admin-ui-options-pages.php:179
+msgid "Options page activated."
+msgid_plural "%s options pages activated."
+msgstr[0] "Opties pagina geactiveerd."
+msgstr[1] "%s opties pagina’s geactiveerd."
+
+#. translators: %s number of post types deactivated
+#: pro/admin/post-types/admin-ui-options-pages.php:186
+msgid "Options page deactivated."
+msgid_plural "%s options pages deactivated."
+msgstr[0] "Opties pagina gedeactiveerd."
+msgstr[1] "%s opties pagina’s gedeactiveerd."
+
+#. translators: %s number of post types duplicated
+#: pro/admin/post-types/admin-ui-options-pages.php:193
+msgid "Options page duplicated."
+msgid_plural "%s options pages duplicated."
+msgstr[0] "Opties pagina gedupliceerd."
+msgstr[1] "%s opties pagina’s gedupliceerd."
+
+#. translators: %s number of post types synchronized
+#: pro/admin/post-types/admin-ui-options-pages.php:200
+msgid "Options page synchronized."
+msgid_plural "%s options pages synchronized."
+msgstr[0] "Opties pagina gesynchroniseerd."
+msgstr[1] "%s opties pagina's gesynchroniseerd."
+
+#: pro/admin/views/html-settings-updates.php:9
+msgid "Deactivate License"
+msgstr "Licentiecode deactiveren"
+
+#: pro/admin/views/html-settings-updates.php:9
+msgid "Activate License"
+msgstr "Licentie activeren"
+
+#: pro/admin/views/html-settings-updates.php:26
+msgctxt "license status"
+msgid "Inactive"
+msgstr "Inactief"
+
+#: pro/admin/views/html-settings-updates.php:34
+msgctxt "license status"
+msgid "Cancelled"
+msgstr "Geannuleerd"
+
+#: pro/admin/views/html-settings-updates.php:32
+msgctxt "license status"
+msgid "Expired"
+msgstr "Verlopen"
+
+#: pro/admin/views/html-settings-updates.php:30
+msgctxt "license status"
+msgid "Active"
+msgstr "Actief"
+
+#: pro/admin/views/html-settings-updates.php:47
+msgid "Subscription Status"
+msgstr "Abonnementsstatus"
+
+#: pro/admin/views/html-settings-updates.php:45
+msgid "License Status"
+msgstr "Licentiestatus"
+
+#: pro/admin/views/html-settings-updates.php:60
+msgid "Subscription Type"
+msgstr "Abonnementstype"
+
+#: pro/admin/views/html-settings-updates.php:58
+msgid "License Type"
+msgstr "Licentietype"
+
+#: pro/admin/views/html-settings-updates.php:67
+msgid "Lifetime - "
+msgstr "Levenslang - "
+
+#: pro/admin/views/html-settings-updates.php:81
+msgid "Subscription Expires"
+msgstr "Abonnement verloopt"
+
+#: pro/admin/views/html-settings-updates.php:79
+msgid "Subscription Expired"
+msgstr "Abonnement verlopen"
+
+#: pro/admin/views/html-settings-updates.php:118
+msgid "Renew Subscription"
+msgstr "Abonnement verlengen"
+
+#: pro/admin/views/html-settings-updates.php:136
+msgid "License Information"
+msgstr "Licentie informatie"
+
+#: pro/admin/views/html-settings-updates.php:170
+msgid "License Key"
+msgstr "Licentiecode"
+
+#: pro/admin/views/html-settings-updates.php:191,
+#: pro/admin/views/html-settings-updates.php:157
+msgid "Recheck License"
+msgstr "Licentie opnieuw controleren"
+
+#: pro/admin/views/html-settings-updates.php:142
+msgid "Your license key is defined in wp-config.php."
+msgstr "Uw licentiesleutel wordt gedefinieerd in wp-config.php."
+
+#: pro/admin/views/html-settings-updates.php:211
+msgid "View pricing & purchase"
+msgstr "Prijzen bekijken & kopen"
+
+#. translators: %s - link to ACF website
+#: pro/admin/views/html-settings-updates.php:220
+msgid "Don't have an ACF PRO license? %s"
+msgstr "Heeft u geen ACF PRO licentie? %s"
+
+#: pro/admin/views/html-settings-updates.php:235
+msgid "Update Information"
+msgstr "Informatie updaten"
+
+#: pro/admin/views/html-settings-updates.php:242
+msgid "Current Version"
+msgstr "Huidige versie"
+
+#: pro/admin/views/html-settings-updates.php:250
+msgid "Latest Version"
+msgstr "Nieuwste versie"
+
+#: pro/admin/views/html-settings-updates.php:258
+msgid "Update Available"
+msgstr "Update beschikbaar"
+
+#: pro/admin/views/html-settings-updates.php:265
+msgid "No"
+msgstr "Nee"
+
+#: pro/admin/views/html-settings-updates.php:263
+msgid "Yes"
+msgstr "Ja"
+
+#: pro/admin/views/html-settings-updates.php:272
+msgid "Upgrade Notice"
+msgstr "Upgrade opmerking"
+
+#: pro/admin/views/html-settings-updates.php:303
+msgid "Check For Updates"
+msgstr "Controleren op updates"
+
+#: pro/admin/views/html-settings-updates.php:300
+msgid "Enter your license key to unlock updates"
+msgstr "Vul uw licentiecode hierboven in om updates te ontgrendelen"
+
+#: pro/admin/views/html-settings-updates.php:298
+msgid "Update Plugin"
+msgstr "Plugin updaten"
+
+#: pro/admin/views/html-settings-updates.php:296
+msgid "Updates must be manually installed in this configuration"
+msgstr "Updates moeten handmatig worden geïnstalleerd in deze configuratie"
+
+#: pro/admin/views/html-settings-updates.php:294
+msgid "Update ACF in Network Admin"
+msgstr "ACF updaten in netwerkbeheer"
+
+#: pro/admin/views/html-settings-updates.php:292
+msgid "Please reactivate your license to unlock updates"
+msgstr "Activeer uw licentie opnieuw om updates te ontgrendelen"
+
+#: pro/admin/views/html-settings-updates.php:290
+msgid "Please upgrade WordPress to update ACF"
+msgstr "Upgrade WordPress om ACF te updaten"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:20
+msgid "Dashicon class name"
+msgstr "Dashicon class naam"
+
+#. translators: %s = "dashicon class name", link to the WordPress dashicon documentation.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:25
+msgid ""
+"The icon used for the options page menu item in the admin dashboard. Can be "
+"a URL or %s to use for the icon."
+msgstr ""
+"Het icoon dat wordt gebruikt voor het menu-item op de opties pagina in het "
+"beheerdashboard. Kan een URL of %s zijn om te gebruiken voor het icoon."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:59
+msgid "Menu Icon"
+msgstr "Menu-icoon"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:80
+msgid "Menu Title"
+msgstr "Menutitel"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:94
+msgid "Learn more about menu positions."
+msgstr "Meer informatie over menuposities."
+
+#. translators: %s - link to WordPress docs to learn more about menu positions.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:98,
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:104
+msgid "The position in the menu where this page should appear. %s"
+msgstr "De positie in het menu waar deze pagina moet verschijnen. %s"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:108
+msgid ""
+"The position in the menu where this child page should appear. The first "
+"child page is 0, the next is 1, etc."
+msgstr ""
+"De positie in het menu waar deze subpagina moet verschijnen. De eerste "
+"subpagina is 0, de volgende is 1, etc."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:115
+msgid "Menu Position"
+msgstr "Menupositie"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:129
+msgid "Redirect to Child Page"
+msgstr "Doorverwijzen naar subpagina"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:130
+msgid ""
+"When child pages exist for this parent page, this page will redirect to the "
+"first child page."
+msgstr ""
+"Als er subpagina's bestaan voor deze hoofdpagina, zal deze pagina doorsturen "
+"naar de eerste subpagina."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:154
+msgid "A descriptive summary of the options page."
+msgstr "Een beschrijvende samenvatting van de opties pagina."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:163
+msgid "Update Button Label"
+msgstr "Update knop label"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:164
+msgid ""
+"The label used for the submit button which updates the fields on the options "
+"page."
+msgstr ""
+"Het label dat wordt gebruikt voor de verzendknop waarmee de velden op de "
+"opties pagina worden geüpdatet."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:178
+msgid "Updated Message"
+msgstr "Bericht geüpdatet"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:179
+msgid ""
+"The message that is displayed after successfully updating the options page."
+msgstr ""
+"Het bericht dat wordt weergegeven na het succesvol updaten van de opties "
+"pagina."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:180
+msgid "Updated Options"
+msgstr "Geüpdatete opties"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:217
+msgid "Capability"
+msgstr "Rechten"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:218
+msgid "The capability required for this menu to be displayed to the user."
+msgstr "De rechten die nodig zijn om dit menu weer te geven aan de gebruiker."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:234
+msgid "Data Storage"
+msgstr "Gegevensopslag"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:235
+msgid ""
+"By default, the option page stores field data in the options table. You can "
+"make the page load field data from a post, user, or term."
+msgstr ""
+"Standaard slaat de opties pagina veldgegevens op in de optietabel. U kunt de "
+"pagina veldgegevens laten laden van een bericht, gebruiker of term."
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:238,
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:269
+msgid "Custom Storage"
+msgstr "Aangepaste opslag"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:258
+msgid "Learn more about available settings."
+msgstr "Meer informatie over beschikbare instellingen."
+
+#. translators: %s = link to learn more about storage locations.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:263
+msgid ""
+"Set a custom storage location. Can be a numeric post ID (123), or a string "
+"(`user_2`). %s"
+msgstr ""
+"Stel een aangepaste opslaglocatie in. Kan een numerieke bericht ID zijn "
+"(123) of een tekenreeks (`user_2`). %s"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:288
+msgid "Autoload Options"
+msgstr "Autoload opties"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:289
+msgid ""
+"Improve performance by loading the fields in the option records "
+"automatically when WordPress loads."
+msgstr ""
+"Verbeter de prestaties door de velden in de optie-records automatisch te "
+"laden wanneer WordPress wordt geladen."
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:20,
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:16
+msgid "Page Title"
+msgstr "Paginatitel"
+
+#. translators: example options page name
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:22,
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:18
+msgid "Site Settings"
+msgstr "Site instellingen"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:37,
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:33
+msgid "Menu Slug"
+msgstr "Menuslug"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:52,
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:47
+msgid "Parent Page"
+msgstr "Hoofdpagina"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:72
+msgid "Advanced Configuration"
+msgstr "Geavanceerde configuratie"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:73
+msgid "I know what I'm doing, show me all the options."
+msgstr "Ik weet wat ik doe, laat me alle opties zien."
+
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:62
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:63
+msgid "Done"
+msgstr "Klaar"
+
+#. translators: %s URL to ACF options pages documentation
+#: pro/admin/views/acf-ui-options-page/list-empty.php:10
+msgid ""
+"ACF <a href=\"%s\" target=\"_blank\">options pages</a> are custom admin "
+"pages for managing global settings via fields. You can create multiple pages "
+"and sub-pages."
+msgstr ""
+"ACF <a href=\"%s\" target=\"_blank\">opties pagina's</a> zijn aangepaste "
+"beheerpagina's voor het beheren van globale instellingen via velden. U kunt "
+"meerdere pagina's en subpagina's maken."
+
+#. translators: %s url to getting started guide
+#: pro/admin/views/acf-ui-options-page/list-empty.php:16
+msgid ""
+"New to ACF? Take a look at our <a href=\"%s\" target=\"_blank\">getting "
+"started guide</a>."
+msgstr ""
+"Bent u nieuw bij ACF? Bekijk onze <a href=\"%s\" "
+"target=\"_blank\">startersgids</a>."
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:32
+msgid "Upgrade to ACF PRO to create options pages in just a few clicks"
+msgstr ""
+"Upgrade naar ACF PRO om opties pagina's te maken in slechts een paar klikken"
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:30
+msgid "Add Your First Options Page"
+msgstr "Voeg uw eerste opties pagina toe"
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:43
+msgid "Learn More"
+msgstr "Meer leren"
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:44
+msgid "Upgrade to ACF PRO"
+msgstr "Upgraden naar ACF PRO"
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:40
+msgid "Add Options Page"
+msgstr "Opties pagina toevoegen"


### PR DESCRIPTION
Added Dutch formal strings from 6.3.7 .pot file and used best practices from Dutch WP glossary