### PR TITLE
Add "acf/validate_save_post_statuses" filter

### DIFF
--- a/includes/forms/form-post.php
+++ b/includes/forms/form-post.php
@@ -307,8 +307,9 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 				return $post_id;
 			}
 
-			// Validate for published post (allow draft to save without validation).
-			if ( $post->post_status === 'publish' ) {
+			// Validate the post. By default, only validate published posts.
+			$validate_post_statuses = apply_filters( 'acf/validate_save_post_statuses', array( 'publish' ) );
+			if ( in_array( $post->post_status, $validate_post_statuses ) ) {
 				// Bail early if validation fails.
 				if ( ! acf_validate_save_post() ) {
 					return;


### PR DESCRIPTION
Hi!

I am using ACF to build an intranet/membership site where we allow people to create "private" content alongside "public" content. Whether the content is only visible to the author or other site members, the content is still displayed on the site and needs to be processed and validated.

I have created code that throws validation errors during the "acf/validate_save_post" hook. The issue is that this hook only runs if the post status is set to "publish" and doesn't run for my "private" content.

This pull request introduces the 'acf/validate_save_post_statuses' filter. The default behavior remains the same (only runs for the "publish" post status) but allows users like myself to hook into this filter to set other post statues for validation.