### PR TITLE
Added: Filter to acf_get_grouped_posts()

### DIFF
--- a/includes/api/api-helpers.php
+++ b/includes/api/api-helpers.php
@@ -1378,8 +1378,16 @@ function acf_get_grouped_posts( $args ) {
 		$data[ $label ] = $this_group;
 	}
 
-	// return
-	return $data;
+	/**
+	 * Filters the results found in the `acf_get_grouped_posts()` function.
+	 * This allows for 3rd party customization.
+	 *
+	 * @since tbd
+	 *
+	 * @param array $data The results from the `get_posts()` call.
+	 * @param array $args The arguments passed to `acf_get_grouped_posts()`.
+	 */
+	return apply_filter( 'acf/get_grouped_posts', $data, $args );
 }
 
 /**


### PR DESCRIPTION
By adding the filter to `acf_get_grouped_posts()` this will enable third party users to alter the output.

In our own usecase, the grouping by post type in the Post Object proofed to be irritating to our editorial staff, so we wanted to ungroup them, and just show an `[post title] - [post type]` in our results. By adding this filter, we would be enabled to do so, without changing anything for anyone else.   