### PR TITLE
Fix PHPDoc comments for update functions

### DIFF
--- a/includes/acf-value-functions.php
+++ b/includes/acf-value-functions.php
@@ -192,7 +192,7 @@ acf_add_filter_variations( 'acf/format_value', array( 'type', 'name', 'key' ), 2
  * @param   mixed        $value   The new value.
  * @param   (int|string) $post_id The post id.
  * @param   array        $field   The field array.
- * @return  boolean
+ * @return  int|boolean Meta ID if the key didn't exist, true on successful update, false on failure.
  */
 function acf_update_value( $value, $post_id, $field ) {
 

--- a/includes/api/api-template.php
+++ b/includes/api/api-template.php
@@ -1133,7 +1133,7 @@ add_shortcode( 'acf', 'acf_shortcode' );
  * @param mixed  $value    The value to save in the database.
  * @param mixed  $post_id  The post_id of which the value is saved against.
  *
- * @return boolean
+ * @return int|boolean Meta ID if the key didn't exist, true on successful update, false on failure.
  */
 function update_field( $selector, $value, $post_id = false ) {
 
@@ -1168,7 +1168,7 @@ function update_field( $selector, $value, $post_id = false ) {
  * @param   $value (mixed) the value to save in the database
  * @param   $post_id (mixed) the post_id of which the value is saved against
  *
- * @return  boolean
+ * @return  int|boolean Meta ID if the key didn't exist, true on successful update, false on failure.
  */
 function update_sub_field( $selector, $value, $post_id = false ) {
 


### PR DESCRIPTION
The return type of `acf_update_metadata` is `integer|boolean` .
See: https://github.com/AdvancedCustomFields/acf/blob/368a95601e81b5c092fc67816b565b60f72fa9a6/includes/acf-meta-functions.php#L166-L169
This is necessary for type consistency with other functions.