### PR TITLE
Fix: Correct site_url handling for custom post types and taxonomies in acf admin

### DIFF
--- a/includes/admin/views/acf-post-type/advanced-settings.php
+++ b/includes/admin/views/acf-post-type/advanced-settings.php
@@ -1052,7 +1052,7 @@ foreach ( acf_get_combined_post_type_settings_tabs() as $tab_key => $tab_label )
 						/* translators: this string will be appended with the new permalink structure. */
 						'custom_permalink_instructions' => __( 'Rewrite the URL using a custom slug defined in the input below. Your permalink structure will be', 'acf' ) . ' {slug}.',
 						'no_permalink_instructions'     => __( 'Permalinks for this post type are disabled.', 'acf' ),
-						'site_url'                      => get_site_url(),
+						'site_url'                      => get_home_url(),
 					),
 					'class'        => 'permalink_rewrite',
 				),

--- a/includes/admin/views/acf-taxonomy/advanced-settings.php
+++ b/includes/admin/views/acf-taxonomy/advanced-settings.php
@@ -43,7 +43,7 @@ foreach ( acf_get_combined_taxonomy_settings_tabs() as $tab_key => $tab_label ) 
 				)
 			);
 			?>
-			
+
 			<?php
 			acf_render_field_wrap(
 				array(
@@ -942,7 +942,7 @@ foreach ( acf_get_combined_taxonomy_settings_tabs() as $tab_key => $tab_label ) 
 						/* translators: this string will be appended with the new permalink structure. */
 						'custom_permalink_instructions' => __( 'Rewrite the URL using a custom slug defined in the input below. Your permalink structure will be', 'acf' ) . ' {slug}.',
 						'no_permalink_instructions'     => __( 'Permalinks for this taxonomy are disabled.', 'acf' ),
-						'site_url'                      => get_site_url(),
+						'site_url'                      => get_home_url(),
 					),
 					'class'        => 'permalink_rewrite',
 				),


### PR DESCRIPTION
In the WordPress admin panel, when viewing the advanced settings for custom post types and taxonomies, the permalink structure is displayed.

However, in environments like [Bedrock](https://roots.io/bedrock/) or when WordPress is installed in a subdirectory such as `/wp`, `site_url()` may include `/wp`, even though this path is not part of the actual public URL.

Example:
- `get_site_url()`: https://example.com/wp
- `get_home_url()`: https://example.com

This caused discrepancies in the displayed URLs.
This PR fixes the issue by ensuring the correct URL is used.