### PR TITLE
fix: Set autoloader to be `--classmap-authoritative`

### DIFF
--- a/vendor/composer/autoload_real.php
+++ b/vendor/composer/autoload_real.php
@@ -29,6 +29,7 @@ class ComposerAutoloaderInit94e23cbc47a4750e27ee21b7644f1866
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInit94e23cbc47a4750e27ee21b7644f1866::getInitializer($loader));
 
+        $loader->setClassMapAuthoritative(true);
         $loader->register(true);
 
         return $loader;


### PR DESCRIPTION
This will tell your Composer autoloader to only look for classes in the declared folders (improved performance/safety).

See: https://naderman.de/slippy/slides/2017-07-13-T3DD17-Composer-Best-Practices.pdf

And: https://github.com/composer/composer/issues/10205#issuecomment-951982388