### PR TITLE
Suggest translation change from "注文番号" to "順番" for "Order No."

### DIFF
--- a/lang/acf-ja.po
+++ b/lang/acf-ja.po
@@ -5379,7 +5379,7 @@ msgstr "下位のフィールドグループを最初に表示"
 
 #: includes/admin/views/acf-field-group/options.php:156
 msgid "Order No."
-msgstr "注文番号"
+msgstr "順番"
 
 #: includes/admin/views/acf-field-group/options.php:147
 msgid "Below fields"


### PR DESCRIPTION
"Order No." can indeed refer to "注文番号" in contexts such as placing orders at a restaurant. However, in this case, it is clearly intended to indicate a sorting or display order. Therefore, I suggest translating it as "順番" (meaning a sequential position) or simply "番号" to more accurately reflect its usage here.