### PR TITLE
fix: use wp_print_inline_script_tag

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -482,7 +482,7 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 			acf_localize_data( $data_to_localize );
 
 			// Print inline script.
-			printf( "<script>\n%s\n</script>\n", 'acf.data = ' . wp_json_encode( $this->data ) . ';' );
+			wp_print_inline_script_tag( 'acf.data = ' . wp_json_encode( $this->data ) . ';' );
 
 			if ( wp_script_is( 'acf-input' ) ) {
 
@@ -495,7 +495,7 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 				 */
 				$compat_l10n = apply_filters( 'acf/input/admin_l10n', array() );
 				if ( $compat_l10n ) {
-					printf( "<script>\n%s\n</script>\n", 'acf.l10n = ' . wp_json_encode( $compat_l10n ) . ';' );
+					wp_print_inline_script_tag( 'acf.l10n = ' . wp_json_encode( $compat_l10n ) . ';' );
 				}
 
 				/**
@@ -518,7 +518,7 @@ if ( ! class_exists( 'ACF_Assets' ) ) :
 			do_action( 'acf/admin_print_footer_scripts' );
 
 			// Once all data is localized, trigger acf.prepare() to execute functionality before DOM ready.
-			printf( "<script>\n%s\n</script>\n", "acf.doAction( 'prepare' );" );
+			wp_print_inline_script_tag( "acf.doAction( 'prepare' );" );
 		}
 
 		/**


### PR DESCRIPTION
When using a strict CSP https://web.dev/articles/strict-csp front end forms break due to the printing of inline script tags.
This PR uses the [wp_print_inline_script_tag](https://developer.wordpress.org/reference/functions/wp_print_inline_script_tag/) functions to print the scripts; this allows the insertion of a nonce attribute which makes the inline script CSP compliant