### PR TITLE
Merge .pot to ja localization

### DIFF
--- a/lang/pro/acf-ja.po
+++ b/lang/pro/acf-ja.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Advanced Custom Fields PRO\n"
 "Report-Msgid-Bugs-To: https://support.advancedcustomfields.com\n"
-"POT-Creation-Date: 2023-04-18 07:25+0000\n"
-"PO-Revision-Date: 2023-04-24 13:30+0100\n"
+"POT-Creation-Date: 2025-09-10 00:29+0000\n"
+"PO-Revision-Date: 2025-09-13 00:01+0200\n"
 "Last-Translator: WP Engine <support@advancedcustomfields.com>\n"
 "Language-Team: WP Engine <support@advancedcustomfields.com>\n"
 "Language: ja_JP\n"
@@ -11,564 +11,646 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-WPHeader: acf.php\n"
 "X-Textdomain-Support: yes\n"
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
-#: pro/acf-pro.php:27
+#: pro/acf-pro.php:62
 msgid "Advanced Custom Fields PRO"
 msgstr "Advanced Custom Fields PRO"
 
-#: pro/blocks.php:170
+#: pro/acf-pro.php:199
+msgid "Your ACF PRO license is no longer active. Please renew to continue to have access to updates, support, & PRO features."
+msgstr ""
+
+#: pro/acf-pro.php:196
+msgid "Your license has expired. Please renew to continue to have access to updates, support &amp; PRO features."
+msgstr ""
+
+#: pro/acf-pro.php:193
+msgid "Activate your license to enable access to updates, support &amp; PRO features."
+msgstr ""
+
+#: pro/acf-pro.php:214, pro/admin/views/html-settings-updates.php:115
+msgid "Manage License"
+msgstr "ライセンスのアクティベートを解除"
+
+#: pro/acf-pro.php:282
+msgid "A valid license is required to edit options pages."
+msgstr ""
+
+#: pro/acf-pro.php:280
+msgid "A valid license is required to edit field groups assigned to a block."
+msgstr ""
+
+#: pro/blocks.php:186
 msgid "Block type name is required."
 msgstr ""
 
 #. translators: The name of the block type
-#: pro/blocks.php:178
+#: pro/blocks.php:194
 msgid "Block type \"%s\" is already registered."
 msgstr ""
 
-#: pro/blocks.php:726
+#: pro/blocks.php:756
+msgid "The render template for this ACF Block was not found"
+msgstr ""
+
+#: pro/blocks.php:806
 msgid "Switch to Edit"
 msgstr ""
 
-#: pro/blocks.php:727
+#: pro/blocks.php:807
 msgid "Switch to Preview"
 msgstr ""
 
-#: pro/blocks.php:728
+#: pro/blocks.php:808
 msgid "Change content alignment"
 msgstr ""
 
+#: pro/blocks.php:809
+msgid "An error occurred when loading the preview for this block."
+msgstr ""
+
+#: pro/blocks.php:810
+msgid "An error occurred when loading the block in edit mode."
+msgstr ""
+
 #. translators: %s: Block type title
-#: pro/blocks.php:731
+#: pro/blocks.php:813
 msgid "%s settings"
 msgstr ""
 
-#: pro/blocks.php:936
+#: pro/blocks.php:1055
 msgid "This block contains no editable fields."
 msgstr ""
 
 #. translators: %s: an admin URL to the field group edit screen
-#: pro/blocks.php:942
-msgid ""
-"Assign a <a href=\"%s\" target=\"_blank\">field group</a> to add fields to "
-"this block."
+#: pro/blocks.php:1061
+msgid "Assign a <a href=\"%s\" target=\"_blank\">field group</a> to add fields to this block."
 msgstr ""
 
-#: pro/options-page.php:47
+#: pro/options-page.php:43, pro/admin/views/acf-ui-options-page/advanced-settings.php:237
 msgid "Options"
 msgstr "オプション"
 
-#: pro/options-page.php:77, pro/fields/class-acf-field-gallery.php:527
+#: pro/options-page.php:73, pro/fields/class-acf-field-gallery.php:483, pro/post-types/acf-ui-options-page.php:173, pro/admin/views/acf-ui-options-page/advanced-settings.php:165
 msgid "Update"
 msgstr "更新"
 
-#: pro/options-page.php:78
+#: pro/options-page.php:74, pro/post-types/acf-ui-options-page.php:174
 msgid "Options Updated"
 msgstr "オプションを更新しました"
 
-#: pro/updates.php:99
-msgid ""
-"To enable updates, please enter your license key on the <a "
-"href=\"%1$s\">Updates</a> page. If you don't have a licence key, please see "
-"<a href=\"%2$s\" target=\"_blank\">details & pricing</a>."
+#. translators: %1 A link to the updates page. %2 link to the pricing page
+#: pro/updates.php:75
+msgid "To enable updates, please enter your license key on the <a href=\"%1$s\">Updates</a> page. If you don't have a license key, please see <a href=\"%2$s\" target=\"_blank\">details & pricing</a>."
+msgstr ""
+
+#: pro/updates.php:71
+msgid "To enable updates, please enter your license key on the <a href=\"%1$s\">Updates</a> page of the main site. If you don't have a license key, please see <a href=\"%2$s\" target=\"_blank\">details & pricing</a>."
+msgstr ""
+
+#: pro/updates.php:136
+msgid "Your defined license key has changed, but an error occurred when deactivating your old license"
+msgstr ""
+
+#: pro/updates.php:133
+msgid "Your defined license key has changed, but an error occurred when connecting to activation server"
+msgstr ""
+
+#: pro/updates.php:168
+msgid "<strong>ACF PRO &mdash;</strong> Your license key has been activated successfully. Access to updates, support &amp; PRO features is now enabled."
 msgstr ""
 
 #: pro/updates.php:159
-msgid ""
-"<b>ACF Activation Error</b>. Your defined license key has changed, but an "
-"error occurred when deactivating your old licence"
+msgid "There was an issue activating your license key."
 msgstr ""
 
-#: pro/updates.php:154
-msgid ""
-"<b>ACF Activation Error</b>. Your defined license key has changed, but an "
-"error occurred when connecting to activation server"
+#: pro/updates.php:155
+msgid "An error occurred when connecting to activation server"
+msgstr "<b>エラー</b> ライセンスサーバーに接続できません"
+
+#: pro/updates.php:260
+msgid "The ACF activation service is temporarily unavailable. Please try again later."
+msgstr ""
+
+#: pro/updates.php:258
+msgid "The ACF activation service is temporarily unavailable for scheduled maintenance. Please try again later."
+msgstr ""
+
+#: pro/updates.php:256
+msgid "An upstream API error occurred when checking your ACF PRO license status. We will retry again shortly."
+msgstr ""
+
+#: pro/updates.php:254
+msgid "Your license is not valid for this site URL. Please contact support for assistance."
+msgstr ""
+
+#: pro/updates.php:224
+msgid "You have reached the activation limit for the license."
+msgstr ""
+
+#: pro/updates.php:233, pro/updates.php:205
+msgid "View your licenses"
+msgstr ""
+
+#: pro/updates.php:246
+msgid "check again"
+msgstr "再確認"
+
+#: pro/updates.php:250
+msgid "%1$s or %2$s."
+msgstr ""
+
+#: pro/updates.php:210
+msgid "Your license key has expired and cannot be activated."
+msgstr ""
+
+#: pro/updates.php:219
+msgid "View your subscriptions"
+msgstr ""
+
+#: pro/updates.php:196
+msgid "License key not found. Make sure you have copied your license key exactly as it appears in your receipt or your account."
+msgstr ""
+
+#: pro/updates.php:194
+msgid "Your license key has been deactivated."
 msgstr ""
 
 #: pro/updates.php:192
-msgid "<b>ACF Activation Error</b>"
+msgid "Your license key has been activated successfully. Access to updates, support &amp; PRO features is now enabled."
 msgstr ""
 
-#: pro/updates.php:187
-msgid ""
-"<b>ACF Activation Error</b>. An error occurred when connecting to activation "
-"server"
+#. translators: %s an untranslatable internal upstream error message
+#: pro/updates.php:264
+msgid "An unknown error occurred while trying to communicate with the ACF activation service: %s."
 msgstr ""
 
-#: pro/updates.php:279
-msgid "Check Again"
+#: pro/updates.php:335, pro/updates.php:951
+msgid "<strong>ACF PRO &mdash;</strong>"
+msgstr ""
+
+#: pro/updates.php:344
+msgid "Check again"
 msgstr "再確認"
 
-#: pro/updates.php:593
-msgid "<b>ACF Activation Error</b>. Could not connect to activation server"
+#: pro/updates.php:659
+msgid "Could not connect to the activation server"
+msgstr "<b>エラー</b> ライセンスサーバーに接続できません"
+
+#. translators: %s - URL to ACF updates page
+#: pro/updates.php:729
+msgid "Your license key is valid but not activated on this site. Please <a href=\"%s\">deactivate</a> and then reactivate the license."
 msgstr ""
 
-#: pro/admin/admin-options-page.php:195
+#: pro/updates.php:951
+msgid "Your site URL has changed since last activating your license. We've automatically activated it for this site URL."
+msgstr ""
+
+#: pro/updates.php:943
+msgid "Your site URL has changed since last activating your license, but we weren't able to automatically reactivate it: %s"
+msgstr ""
+
+#: pro/admin/admin-options-page.php:159
 msgid "Publish"
 msgstr "公開"
 
-#: pro/admin/admin-options-page.php:199
-msgid ""
-"No Custom Field Groups found for this options page. <a href=\"%s\">Create a "
-"Custom Field Group</a>"
-msgstr ""
-"このオプションページにカスタムフィールドグループがありません. <a href=\"%s\">"
-"カスタムフィールドグループを作成</a>"
+#: pro/admin/admin-options-page.php:162
+msgid "No Custom Field Groups found for this options page. <a href=\"%s\">Create a Custom Field Group</a>"
+msgstr "このオプションページにカスタムフィールドグループがありません. <a href=\"%s\">カスタムフィールドグループを作成</a>"
 
-#: pro/admin/admin-options-page.php:309
+#: pro/admin/admin-options-page.php:258
 msgid "Edit field group"
 msgstr "フィールドグループを編集"
 
 #: pro/admin/admin-updates.php:52
-msgid "<b>Error</b>. Could not connect to update server"
+msgid "<strong>Error</strong>. Could not connect to the update server"
 msgstr "<b>エラー</b> 更新サーバーに接続できません"
 
-#: pro/admin/admin-updates.php:122,
-#: pro/admin/views/html-settings-updates.php:12
+#: pro/admin/admin-updates.php:117, pro/admin/admin-updates.php:117, pro/admin/views/html-settings-updates.php:133
 msgid "Updates"
 msgstr "アップデート"
 
-#: pro/admin/admin-updates.php:212
-msgid ""
-"<b>Error</b>. Could not authenticate update package. Please check again or "
-"deactivate and reactivate your ACF PRO license."
+#. translators: %s the version of WordPress required for this ACF update
+#: pro/admin/admin-updates.php:203
+msgid "An update to ACF is available, but it is not compatible with your version of WordPress. Please upgrade to WordPress %s or newer to update ACF."
 msgstr ""
 
-#: pro/admin/admin-updates.php:199
-msgid ""
-"<b>Error</b>. Your license for this site has expired or been deactivated. "
-"Please reactivate your ACF PRO license."
+#: pro/admin/admin-updates.php:224
+msgid "<strong>Error</strong>. Could not authenticate update package. Please check again or deactivate and reactivate your ACF PRO license."
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:25
+#: pro/admin/admin-updates.php:214
+msgid "<strong>Error</strong>. Your license for this site has expired or been deactivated. Please reactivate your ACF PRO license."
+msgstr ""
+
+#: pro/fields/class-acf-field-clone.php:27
 msgctxt "noun"
 msgid "Clone"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:27,
-#: pro/fields/class-acf-field-repeater.php:31
-msgid ""
-"Allows you to select and display existing fields. It does not duplicate any "
-"fields in the database, but loads and displays the selected fields at run-"
-"time. The Clone field can either replace itself with the selected fields or "
-"display the selected fields as a group of subfields."
+#: pro/fields/class-acf-field-clone.php:29
+msgid "Allows you to select and display existing fields. It does not duplicate any fields in the database, but loads and displays the selected fields at run-time. The Clone field can either replace itself with the selected fields or display the selected fields as a group of subfields."
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:818,
-#: pro/fields/class-acf-field-flexible-content.php:78
+#: pro/fields/class-acf-field-clone.php:728, pro/fields/class-acf-field-flexible-content.php:84
 msgid "Fields"
 msgstr "フィールド"
 
-#: pro/fields/class-acf-field-clone.php:819
+#: pro/fields/class-acf-field-clone.php:729
 msgid "Select one or more fields you wish to clone"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:838
+#: pro/fields/class-acf-field-clone.php:749
 msgid "Display"
 msgstr "表示"
 
-#: pro/fields/class-acf-field-clone.php:839
+#: pro/fields/class-acf-field-clone.php:750
 msgid "Specify the style used to render the clone field"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:844
+#: pro/fields/class-acf-field-clone.php:755
 msgid "Group (displays selected fields in a group within this field)"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:845
+#: pro/fields/class-acf-field-clone.php:756
 msgid "Seamless (replaces this field with selected fields)"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:854,
-#: pro/fields/class-acf-field-flexible-content.php:558,
-#: pro/fields/class-acf-field-flexible-content.php:616,
-#: pro/fields/class-acf-field-repeater.php:177
+#: pro/fields/class-acf-field-clone.php:765, pro/fields/class-acf-field-flexible-content.php:345, pro/fields/class-acf-field-flexible-content.php:408, pro/fields/class-acf-field-repeater.php:180
 msgid "Layout"
 msgstr "レイアウト"
 
-#: pro/fields/class-acf-field-clone.php:855
+#: pro/fields/class-acf-field-clone.php:766
 msgid "Specify the style used to render the selected fields"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:860,
-#: pro/fields/class-acf-field-flexible-content.php:629,
-#: pro/fields/class-acf-field-repeater.php:185,
-#: pro/locations/class-acf-location-block.php:22
+#: pro/fields/class-acf-field-clone.php:771, pro/fields/class-acf-field-flexible-content.php:421, pro/fields/class-acf-field-repeater.php:188, pro/locations/class-acf-location-block.php:22
 msgid "Block"
 msgstr "ブロック"
 
-#: pro/fields/class-acf-field-clone.php:861,
-#: pro/fields/class-acf-field-flexible-content.php:628,
-#: pro/fields/class-acf-field-repeater.php:184
+#: pro/fields/class-acf-field-clone.php:772, pro/fields/class-acf-field-flexible-content.php:420, pro/fields/class-acf-field-repeater.php:187
 msgid "Table"
 msgstr "表"
 
-#: pro/fields/class-acf-field-clone.php:862,
-#: pro/fields/class-acf-field-flexible-content.php:630,
-#: pro/fields/class-acf-field-repeater.php:186
+#: pro/fields/class-acf-field-clone.php:773, pro/fields/class-acf-field-flexible-content.php:422, pro/fields/class-acf-field-repeater.php:189
 msgid "Row"
 msgstr "行"
 
-#: pro/fields/class-acf-field-clone.php:868
+#: pro/fields/class-acf-field-clone.php:779
 msgid "Labels will be displayed as %s"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:873
+#: pro/fields/class-acf-field-clone.php:784
 msgid "Prefix Field Labels"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:883
+#: pro/fields/class-acf-field-clone.php:794
 msgid "Values will be saved as %s"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:888
+#: pro/fields/class-acf-field-clone.php:799
 msgid "Prefix Field Names"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:1005
+#: pro/fields/class-acf-field-clone.php:896
 msgid "Unknown field"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:1009
+#: pro/fields/class-acf-field-clone.php:900
 msgid "(no title)"
 msgstr "（無題）"
 
-#: pro/fields/class-acf-field-clone.php:1042
+#: pro/fields/class-acf-field-clone.php:929
 msgid "Unknown field group"
 msgstr ""
 
-#: pro/fields/class-acf-field-clone.php:1046
+#: pro/fields/class-acf-field-clone.php:933
 msgid "All fields from %s field group"
 msgstr ""
 
-#: pro/fields/class-acf-field-flexible-content.php:25
+#: pro/fields/class-acf-field-flexible-content.php:38
 msgid "Flexible Content"
 msgstr "柔軟コンテンツ"
 
-#: pro/fields/class-acf-field-flexible-content.php:27
-msgid ""
-"Allows you to define, create and manage content with total control by "
-"creating layouts that contain subfields that content editors can choose from."
+#: pro/fields/class-acf-field-flexible-content.php:40
+msgid "Allows you to define, create and manage content with total control by creating layouts that contain subfields that content editors can choose from."
 msgstr ""
 
-#: pro/fields/class-acf-field-flexible-content.php:27
+#: pro/fields/class-acf-field-flexible-content.php:40
 msgid "We do not recommend using this field in ACF Blocks."
 msgstr ""
 
-#: pro/fields/class-acf-field-flexible-content.php:36,
-#: pro/fields/class-acf-field-repeater.php:103,
-#: pro/fields/class-acf-field-repeater.php:297
+#: pro/fields/class-acf-field-flexible-content.php:50, pro/fields/class-acf-field-repeater.php:104, pro/fields/class-acf-field-repeater.php:300
 msgid "Add Row"
 msgstr "行を追加"
 
-#: pro/fields/class-acf-field-flexible-content.php:76,
-#: pro/fields/class-acf-field-flexible-content.php:943,
-#: pro/fields/class-acf-field-flexible-content.php:1022
-#, fuzzy
-#| msgid "layout"
+#: pro/fields/class-acf-field-flexible-content.php:82, pro/fields/class-acf-field-flexible-content.php:748, pro/fields/class-acf-field-flexible-content.php:834
 msgid "layout"
 msgid_plural "layouts"
 msgstr[0] "レイアウト"
 
-#: pro/fields/class-acf-field-flexible-content.php:77
+#: pro/fields/class-acf-field-flexible-content.php:83
 msgid "layouts"
 msgstr "レイアウト"
 
-#: pro/fields/class-acf-field-flexible-content.php:81,
-#: pro/fields/class-acf-field-flexible-content.php:942,
-#: pro/fields/class-acf-field-flexible-content.php:1021
-msgid "This field requires at least {min} {label} {identifier}"
-msgstr "{identifier}に{label}は最低{min}個必要です"
+#: pro/fields/class-acf-field-flexible-content.php:87, src/pro/Fields/FlexibleContent/Layout.php:247
+msgid "Duplicate"
+msgstr "複製"
 
-#: pro/fields/class-acf-field-flexible-content.php:82
-msgid "This field has a limit of {max} {label} {identifier}"
-msgstr ""
+#: pro/fields/class-acf-field-flexible-content.php:88, src/pro/Fields/FlexibleContent/Layout.php:248
+msgid "Delete"
+msgstr "削除"
 
-#: pro/fields/class-acf-field-flexible-content.php:85
-msgid "{available} {label} {identifier} available (max {max})"
-msgstr ""
-"あと{available}個 {identifier}には {label} を利用できます（最大 {max}個）"
-
-#: pro/fields/class-acf-field-flexible-content.php:86
-msgid "{required} {label} {identifier} required (min {min})"
-msgstr ""
-"あと{required}個 {identifier}には {label} を利用する必要があります（最小 "
-"{max}個）"
-
-#: pro/fields/class-acf-field-flexible-content.php:89
-msgid "Flexible Content requires at least 1 layout"
-msgstr "柔軟コンテンツは少なくとも1個のレイアウトが必要です"
-
-#: pro/fields/class-acf-field-flexible-content.php:282
-msgid "Click the \"%s\" button below to start creating your layout"
-msgstr "下の \"%s\" ボタンをクリックしてレイアウトの作成を始めてください"
-
-#: pro/fields/class-acf-field-flexible-content.php:420,
-#: pro/fields/class-acf-repeater-table.php:366
-msgid "Drag to reorder"
-msgstr "ドラッグして並び替え"
-
-#: pro/fields/class-acf-field-flexible-content.php:423
-msgid "Add layout"
-msgstr "レイアウトを追加"
-
-#: pro/fields/class-acf-field-flexible-content.php:424
-msgid "Duplicate layout"
-msgstr ""
-
-#: pro/fields/class-acf-field-flexible-content.php:425
-msgid "Remove layout"
-msgstr "レイアウトを削除"
-
-#: pro/fields/class-acf-field-flexible-content.php:426,
-#: pro/fields/class-acf-repeater-table.php:382
-msgid "Click to toggle"
-msgstr ""
-
-#: pro/fields/class-acf-field-flexible-content.php:562
+#: pro/fields/class-acf-field-flexible-content.php:89, pro/fields/class-acf-field-flexible-content.php:353
 msgid "Delete Layout"
 msgstr "レイアウトを削除"
 
-#: pro/fields/class-acf-field-flexible-content.php:563
+#. translators: %s - Name of the Flexible content layout
+#: pro/fields/class-acf-field-flexible-content.php:91
+msgid "Delete %s"
+msgstr "%s を削除"
+
+#: pro/fields/class-acf-field-flexible-content.php:92
+msgid "Are you sure you want to delete the layout?"
+msgstr ""
+
+#. translators: %s - Name of the Flexible content layout
+#: pro/fields/class-acf-field-flexible-content.php:94
+msgid "Are you sure you want to delete %s?"
+msgstr ""
+
+#: pro/fields/class-acf-field-flexible-content.php:97
+msgid "Rename Layout"
+msgstr "レイアウトの名前を変更"
+
+#: pro/fields/class-acf-field-flexible-content.php:98, src/pro/Fields/FlexibleContent/Render.php:252
+msgid "Rename"
+msgstr "名前の変更"
+
+#: pro/fields/class-acf-field-flexible-content.php:99
+msgid "New Label"
+msgstr "新しいラベル"
+
+#: pro/fields/class-acf-field-flexible-content.php:100
+msgid "Remove Custom Label"
+msgstr ""
+
+#: pro/fields/class-acf-field-flexible-content.php:103, pro/fields/class-acf-field-flexible-content.php:747, pro/fields/class-acf-field-flexible-content.php:833
+msgid "This field requires at least {min} {label} {identifier}"
+msgstr "{identifier}に{label}は最低{min}個必要です"
+
+#: pro/fields/class-acf-field-flexible-content.php:104
+msgid "This field has a limit of {max} {label} {identifier}"
+msgstr ""
+
+#: pro/fields/class-acf-field-flexible-content.php:105
+msgid "Maximum rows reached ({max})"
+msgstr "最大行数に達しました（{max}）"
+
+#: pro/fields/class-acf-field-flexible-content.php:106
+msgid "Maximum {label} {identifier} reached ({max})"
+msgstr ""
+
+#: pro/fields/class-acf-field-flexible-content.php:109
+msgid "{available} {label} {identifier} available (max {max})"
+msgstr "あと{available}個 {identifier}には {label} を利用できます（最大 {max}）"
+
+#: pro/fields/class-acf-field-flexible-content.php:110
+msgid "{required} {label} {identifier} required (min {min})"
+msgstr "あと{required}個 {identifier}には {label} を利用する必要があります（最小 {min}）"
+
+#: pro/fields/class-acf-field-flexible-content.php:113
+msgid "Flexible Content requires at least 1 layout"
+msgstr "柔軟コンテンツは少なくとも1個のレイアウトが必要です"
+
+#: pro/fields/class-acf-field-flexible-content.php:354
 msgid "Duplicate Layout"
 msgstr "レイアウトを複製"
 
-#: pro/fields/class-acf-field-flexible-content.php:564
+#: pro/fields/class-acf-field-flexible-content.php:355
 msgid "Add New Layout"
 msgstr "新しいレイアウトを追加"
 
-#: pro/fields/class-acf-field-flexible-content.php:564
-#, fuzzy
-#| msgid "Add layout"
+#: pro/fields/class-acf-field-flexible-content.php:355
 msgid "Add Layout"
 msgstr "レイアウトを追加"
 
-#: pro/fields/class-acf-field-flexible-content.php:593
+#: pro/fields/class-acf-field-flexible-content.php:384
 msgid "Label"
 msgstr "ラベル"
 
-#: pro/fields/class-acf-field-flexible-content.php:609
+#: pro/fields/class-acf-field-flexible-content.php:401
 msgid "Name"
 msgstr "名前"
 
-#: pro/fields/class-acf-field-flexible-content.php:647
+#: pro/fields/class-acf-field-flexible-content.php:439
 msgid "Min"
 msgstr "最小数"
 
-#: pro/fields/class-acf-field-flexible-content.php:662
+#: pro/fields/class-acf-field-flexible-content.php:454
 msgid "Max"
 msgstr "最大数"
 
-#: pro/fields/class-acf-field-flexible-content.php:705
+#: pro/fields/class-acf-field-flexible-content.php:495
 msgid "Minimum Layouts"
 msgstr "レイアウトの最小数"
 
-#: pro/fields/class-acf-field-flexible-content.php:716
+#: pro/fields/class-acf-field-flexible-content.php:506
 msgid "Maximum Layouts"
 msgstr "レイアウトの最大数"
 
-#: pro/fields/class-acf-field-flexible-content.php:727,
-#: pro/fields/class-acf-field-repeater.php:293
+#: pro/fields/class-acf-field-flexible-content.php:517, pro/fields/class-acf-field-repeater.php:296
 msgid "Button Label"
 msgstr "ボタンのラベル"
 
-#: pro/fields/class-acf-field-flexible-content.php:1710,
-#: pro/fields/class-acf-field-repeater.php:918
+#: pro/fields/class-acf-field-flexible-content.php:1507, pro/fields/class-acf-field-repeater.php:915
 msgid "%s must be of type array or null."
 msgstr ""
 
-#: pro/fields/class-acf-field-flexible-content.php:1721
+#: pro/fields/class-acf-field-flexible-content.php:1518
 msgid "%1$s must contain at least %2$s %3$s layout."
 msgid_plural "%1$s must contain at least %2$s %3$s layouts."
 msgstr[0] ""
 
-#: pro/fields/class-acf-field-flexible-content.php:1737
+#: pro/fields/class-acf-field-flexible-content.php:1534
 msgid "%1$s must contain at most %2$s %3$s layout."
 msgid_plural "%1$s must contain at most %2$s %3$s layouts."
 msgstr[0] ""
 
-#: pro/fields/class-acf-field-gallery.php:25
+#: pro/fields/class-acf-field-gallery.php:22
 msgid "Gallery"
 msgstr "ギャラリー"
 
-#: pro/fields/class-acf-field-gallery.php:27
-msgid ""
-"An interactive interface for managing a collection of attachments, such as "
-"images."
+#: pro/fields/class-acf-field-gallery.php:24
+msgid "An interactive interface for managing a collection of attachments, such as images."
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:77
+#: pro/fields/class-acf-field-gallery.php:72
 msgid "Add Image to Gallery"
 msgstr "ギャラリーに画像を追加"
 
-#: pro/fields/class-acf-field-gallery.php:78
+#: pro/fields/class-acf-field-gallery.php:73
 msgid "Maximum selection reached"
 msgstr "選択の最大数に到達しました"
 
-#: pro/fields/class-acf-field-gallery.php:324
+#: pro/fields/class-acf-field-gallery.php:282
 msgid "Length"
 msgstr "長さ"
 
-#: pro/fields/class-acf-field-gallery.php:339
+#: pro/fields/class-acf-field-gallery.php:297
 msgid "Edit"
 msgstr "編集"
 
-#: pro/fields/class-acf-field-gallery.php:340,
-#: pro/fields/class-acf-field-gallery.php:495
+#: pro/fields/class-acf-field-gallery.php:298, pro/fields/class-acf-field-gallery.php:451
 msgid "Remove"
 msgstr "取り除く"
 
-#: pro/fields/class-acf-field-gallery.php:356
+#: pro/fields/class-acf-field-gallery.php:314
 msgid "Title"
 msgstr "タイトル"
 
-#: pro/fields/class-acf-field-gallery.php:368
+#: pro/fields/class-acf-field-gallery.php:326
 msgid "Caption"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:380
+#: pro/fields/class-acf-field-gallery.php:338
 msgid "Alt Text"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:392
+#: pro/fields/class-acf-field-gallery.php:350, pro/admin/post-types/admin-ui-options-pages.php:113, pro/admin/views/acf-ui-options-page/advanced-settings.php:153
 msgid "Description"
 msgstr "説明"
 
-#: pro/fields/class-acf-field-gallery.php:504
+#: pro/fields/class-acf-field-gallery.php:460
 msgid "Add to gallery"
 msgstr "ギャラリーを追加"
 
-#: pro/fields/class-acf-field-gallery.php:508
+#: pro/fields/class-acf-field-gallery.php:464
 msgid "Bulk actions"
 msgstr "一括操作"
 
-#: pro/fields/class-acf-field-gallery.php:509
+#: pro/fields/class-acf-field-gallery.php:465
 msgid "Sort by date uploaded"
 msgstr "アップロード日で並べ替え"
 
-#: pro/fields/class-acf-field-gallery.php:510
+#: pro/fields/class-acf-field-gallery.php:466
 msgid "Sort by date modified"
 msgstr "変更日で並び替え"
 
-#: pro/fields/class-acf-field-gallery.php:511
+#: pro/fields/class-acf-field-gallery.php:467
 msgid "Sort by title"
 msgstr "タイトルで並び替え"
 
-#: pro/fields/class-acf-field-gallery.php:512
+#: pro/fields/class-acf-field-gallery.php:468
 msgid "Reverse current order"
 msgstr "並び順を逆にする"
 
-#: pro/fields/class-acf-field-gallery.php:524
+#: pro/fields/class-acf-field-gallery.php:480
 msgid "Close"
 msgstr "閉じる"
 
-#: pro/fields/class-acf-field-gallery.php:556
+#: pro/fields/class-acf-field-gallery.php:508
 msgid "Return Format"
 msgstr "返り値のフォーマット"
 
-#: pro/fields/class-acf-field-gallery.php:562
+#: pro/fields/class-acf-field-gallery.php:514
 msgid "Image Array"
 msgstr "画像 配列"
 
-#: pro/fields/class-acf-field-gallery.php:563
+#: pro/fields/class-acf-field-gallery.php:515
 msgid "Image URL"
 msgstr "画像 URL"
 
-#: pro/fields/class-acf-field-gallery.php:564
+#: pro/fields/class-acf-field-gallery.php:516
 msgid "Image ID"
 msgstr "画像 ID"
 
-#: pro/fields/class-acf-field-gallery.php:572
+#: pro/fields/class-acf-field-gallery.php:524
 msgid "Library"
 msgstr "ライブラリ"
 
-#: pro/fields/class-acf-field-gallery.php:573
+#: pro/fields/class-acf-field-gallery.php:525
 msgid "Limit the media library choice"
 msgstr "制限するメディアライブラリを選択"
 
-#: pro/fields/class-acf-field-gallery.php:578,
-#: pro/locations/class-acf-location-block.php:66
+#: pro/fields/class-acf-field-gallery.php:530, pro/locations/class-acf-location-block.php:68
 msgid "All"
 msgstr "全て"
 
-#: pro/fields/class-acf-field-gallery.php:579
+#: pro/fields/class-acf-field-gallery.php:531
 msgid "Uploaded to post"
 msgstr "投稿にアップロードされる"
 
-#: pro/fields/class-acf-field-gallery.php:615
+#: pro/fields/class-acf-field-gallery.php:567
 msgid "Minimum Selection"
 msgstr "最小選択数"
 
-#: pro/fields/class-acf-field-gallery.php:625
+#: pro/fields/class-acf-field-gallery.php:577
 msgid "Maximum Selection"
 msgstr "最大選択数"
 
-#: pro/fields/class-acf-field-gallery.php:635
+#: pro/fields/class-acf-field-gallery.php:587
 msgid "Minimum"
 msgstr "最小"
 
-#: pro/fields/class-acf-field-gallery.php:636,
-#: pro/fields/class-acf-field-gallery.php:672
+#: pro/fields/class-acf-field-gallery.php:588, pro/fields/class-acf-field-gallery.php:624
 msgid "Restrict which images can be uploaded"
 msgstr "アップロード可能な画像を制限"
 
-#: pro/fields/class-acf-field-gallery.php:639,
-#: pro/fields/class-acf-field-gallery.php:675
+#: pro/fields/class-acf-field-gallery.php:591, pro/fields/class-acf-field-gallery.php:627
 msgid "Width"
 msgstr "幅"
 
-#: pro/fields/class-acf-field-gallery.php:650,
-#: pro/fields/class-acf-field-gallery.php:686
+#: pro/fields/class-acf-field-gallery.php:602, pro/fields/class-acf-field-gallery.php:638
 msgid "Height"
 msgstr "高さ"
 
-#: pro/fields/class-acf-field-gallery.php:662,
-#: pro/fields/class-acf-field-gallery.php:698
+#: pro/fields/class-acf-field-gallery.php:614, pro/fields/class-acf-field-gallery.php:650
 msgid "File size"
 msgstr "ファイルサイズ"
 
-#: pro/fields/class-acf-field-gallery.php:671
+#: pro/fields/class-acf-field-gallery.php:623
 msgid "Maximum"
 msgstr "最大"
 
-#: pro/fields/class-acf-field-gallery.php:707
-msgid "Allowed file types"
+#: pro/fields/class-acf-field-gallery.php:659
+msgid "Allowed File Types"
 msgstr "許可するファイルタイプ"
 
-#: pro/fields/class-acf-field-gallery.php:708
+#: pro/fields/class-acf-field-gallery.php:660
 msgid "Comma separated list. Leave blank for all types"
 msgstr "カンマ区切りのリストで入力。全てのタイプを許可する場合は空白のままで"
 
-#: pro/fields/class-acf-field-gallery.php:727
+#: pro/fields/class-acf-field-gallery.php:679
 msgid "Insert"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:728
+#: pro/fields/class-acf-field-gallery.php:680
 msgid "Specify where new attachments are added"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:732
+#: pro/fields/class-acf-field-gallery.php:684
 msgid "Append to the end"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:733
+#: pro/fields/class-acf-field-gallery.php:685
 msgid "Prepend to the beginning"
 msgstr ""
 
-#: pro/fields/class-acf-field-gallery.php:741
+#: pro/fields/class-acf-field-gallery.php:693
 msgid "Preview Size"
 msgstr "プレビューサイズ"
 
-#: pro/fields/class-acf-field-gallery.php:844
+#: pro/fields/class-acf-field-gallery.php:787
 msgid "%1$s requires at least %2$s selection"
 msgid_plural "%1$s requires at least %2$s selections"
 msgstr[0] ""
@@ -577,132 +659,125 @@ msgstr[0] ""
 msgid "Repeater"
 msgstr "繰り返しフィールド"
 
-#: pro/fields/class-acf-field-repeater.php:66,
-#: pro/fields/class-acf-field-repeater.php:463
-#, fuzzy
-#| msgid "Minimum rows reached ({min} rows)"
+#: pro/fields/class-acf-field-repeater.php:31
+msgid "Provides a solution for repeating content such as slides, team members, and call-to-action tiles, by acting as a parent to a set of subfields which can be repeated again and again."
+msgstr ""
+
+#: pro/fields/class-acf-field-repeater.php:67, pro/fields/class-acf-field-repeater.php:464
 msgid "Minimum rows not reached ({min} rows)"
 msgstr "最小行数に達しました（{min} 行）"
 
-#: pro/fields/class-acf-field-repeater.php:67
+#: pro/fields/class-acf-field-repeater.php:68
 msgid "Maximum rows reached ({max} rows)"
 msgstr "最大行数に達しました（{max} 行）"
 
-#: pro/fields/class-acf-field-repeater.php:68
+#: pro/fields/class-acf-field-repeater.php:69
 msgid "Error loading page"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:69
+#: pro/fields/class-acf-field-repeater.php:70
 msgid "Order will be assigned upon save"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:162
+#: pro/fields/class-acf-field-repeater.php:165
 msgid "Sub Fields"
 msgstr "サブフィールド"
 
-#: pro/fields/class-acf-field-repeater.php:195
+#: pro/fields/class-acf-field-repeater.php:198
 msgid "Pagination"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:196
+#: pro/fields/class-acf-field-repeater.php:199
 msgid "Useful for fields with a large number of rows."
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:207
+#: pro/fields/class-acf-field-repeater.php:210
 msgid "Rows Per Page"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:208
+#: pro/fields/class-acf-field-repeater.php:211
 msgid "Set the number of rows to be displayed on a page."
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:240
+#: pro/fields/class-acf-field-repeater.php:243
 msgid "Minimum Rows"
 msgstr "最小行数"
 
-#: pro/fields/class-acf-field-repeater.php:251
+#: pro/fields/class-acf-field-repeater.php:254
 msgid "Maximum Rows"
 msgstr "最大行数"
 
-#: pro/fields/class-acf-field-repeater.php:281
+#: pro/fields/class-acf-field-repeater.php:284
 msgid "Collapsed"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:282
+#: pro/fields/class-acf-field-repeater.php:285
 msgid "Select a sub field to show when row is collapsed"
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:1045
+#: pro/fields/class-acf-field-repeater.php:1053
 msgid "Invalid nonce."
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:1060
+#: pro/fields/class-acf-field-repeater.php:1058
 msgid "Invalid field key or name."
 msgstr ""
 
-#: pro/fields/class-acf-field-repeater.php:1069
+#: pro/fields/class-acf-field-repeater.php:1067
 msgid "There was an error retrieving the field."
 msgstr ""
 
-#: pro/fields/class-acf-repeater-table.php:369
-#, fuzzy
-#| msgid "Drag to reorder"
+#: pro/fields/class-acf-repeater-table.php:365, src/pro/Fields/FlexibleContent/Layout.php:234
+msgid "Drag to reorder"
+msgstr "ドラッグして並び替え"
+
+#: pro/fields/class-acf-repeater-table.php:368
 msgid "Click to reorder"
 msgstr "ドラッグして並び替え"
 
-#: pro/fields/class-acf-repeater-table.php:402
+#: pro/fields/class-acf-repeater-table.php:381
+msgid "Click to toggle"
+msgstr ""
+
+#: pro/fields/class-acf-repeater-table.php:401
 msgid "Add row"
 msgstr "行を追加"
 
-#: pro/fields/class-acf-repeater-table.php:403
+#: pro/fields/class-acf-repeater-table.php:402
 msgid "Duplicate row"
 msgstr ""
 
-#: pro/fields/class-acf-repeater-table.php:404
+#: pro/fields/class-acf-repeater-table.php:403
 msgid "Remove row"
 msgstr "行を削除"
 
-#: pro/fields/class-acf-repeater-table.php:448,
-#: pro/fields/class-acf-repeater-table.php:465,
-#: pro/fields/class-acf-repeater-table.php:466
+#: pro/fields/class-acf-repeater-table.php:447, pro/fields/class-acf-repeater-table.php:464, pro/fields/class-acf-repeater-table.php:465
 msgid "Current Page"
 msgstr ""
 
-#: pro/fields/class-acf-repeater-table.php:456,
-#: pro/fields/class-acf-repeater-table.php:457
-#, fuzzy
-#| msgid "Front Page"
+#: pro/fields/class-acf-repeater-table.php:455, pro/fields/class-acf-repeater-table.php:456
 msgid "First Page"
-msgstr "フロントページ"
+msgstr "最初のページ"
 
-#: pro/fields/class-acf-repeater-table.php:460,
-#: pro/fields/class-acf-repeater-table.php:461
-#, fuzzy
-#| msgid "Posts Page"
+#: pro/fields/class-acf-repeater-table.php:459, pro/fields/class-acf-repeater-table.php:460
 msgid "Previous Page"
-msgstr "投稿ページ"
+msgstr "前のページ"
 
 #. translators: 1: Current page, 2: Total pages.
-#: pro/fields/class-acf-repeater-table.php:470
+#: pro/fields/class-acf-repeater-table.php:469
 msgctxt "paging"
 msgid "%1$s of %2$s"
 msgstr ""
 
-#: pro/fields/class-acf-repeater-table.php:477,
-#: pro/fields/class-acf-repeater-table.php:478
-#, fuzzy
-#| msgid "Front Page"
+#: pro/fields/class-acf-repeater-table.php:476, pro/fields/class-acf-repeater-table.php:477
 msgid "Next Page"
-msgstr "フロントページ"
+msgstr "次のページ"
 
-#: pro/fields/class-acf-repeater-table.php:481,
-#: pro/fields/class-acf-repeater-table.php:482
-#, fuzzy
-#| msgid "Posts Page"
+#: pro/fields/class-acf-repeater-table.php:480, pro/fields/class-acf-repeater-table.php:481
 msgid "Last Page"
-msgstr "投稿ページ"
+msgstr "最後のページ"
 
-#: pro/locations/class-acf-location-block.php:71
+#: pro/locations/class-acf-location-block.php:73
 msgid "No block types exist"
 msgstr ""
 
@@ -711,82 +786,514 @@ msgid "Options Page"
 msgstr "オプションページ"
 
 #: pro/locations/class-acf-location-options-page.php:70
-msgid "No options pages exist"
-msgstr "オプションページはありません"
+msgid "Select options page..."
+msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:6
+#: pro/locations/class-acf-location-options-page.php:74, pro/post-types/acf-ui-options-page.php:95, pro/admin/post-types/admin-ui-options-page.php:482
+msgid "Add New Options Page"
+msgstr "新しいオプションページを追加"
+
+#: pro/post-types/acf-ui-options-page.php:92, pro/post-types/acf-ui-options-page.php:93, pro/admin/post-types/admin-ui-options-pages.php:91, pro/admin/post-types/admin-ui-options-pages.php:91
+msgid "Options Pages"
+msgstr "オプションページ"
+
+#: pro/post-types/acf-ui-options-page.php:94
+msgid "Add New"
+msgstr "新規追加"
+
+#: pro/post-types/acf-ui-options-page.php:96
+msgid "Edit Options Page"
+msgstr "オプションページを編集"
+
+#: pro/post-types/acf-ui-options-page.php:97
+msgid "New Options Page"
+msgstr "新しいオプションページ"
+
+#: pro/post-types/acf-ui-options-page.php:98
+msgid "View Options Page"
+msgstr "オプションページを表示"
+
+#: pro/post-types/acf-ui-options-page.php:99
+msgid "Search Options Pages"
+msgstr "オプションページを検索"
+
+#: pro/post-types/acf-ui-options-page.php:100
+msgid "No Options Pages found"
+msgstr "オプションページが見つかりません"
+
+#: pro/post-types/acf-ui-options-page.php:101
+msgid "No Options Pages found in Trash"
+msgstr "ゴミ箱にオプションページはありません"
+
+#: pro/post-types/acf-ui-options-page.php:203
+msgid "The menu slug must only contain lower case alphanumeric characters, underscores or dashes."
+msgstr ""
+
+#: pro/post-types/acf-ui-options-page.php:235
+msgid "This Menu Slug is already in use by another ACF Options Page."
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:56
+msgid "Options page deleted."
+msgstr "オプションを削除しました"
+
+#: pro/admin/post-types/admin-ui-options-page.php:57
+msgid "Options page updated."
+msgstr "オプションを更新しました"
+
+#: pro/admin/post-types/admin-ui-options-page.php:60
+msgid "Options page saved."
+msgstr "オプションページを保存しました"
+
+#: pro/admin/post-types/admin-ui-options-page.php:61
+msgid "Options page submitted."
+msgstr "オプションを更新しました"
+
+#: pro/admin/post-types/admin-ui-options-page.php:62
+msgid "Options page scheduled for."
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:63
+msgid "Options page draft updated."
+msgstr "オプションのドラフトを更新しました"
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:83
+msgid "%s options page updated"
+msgstr "%s のオプションを更新しました"
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:85
+msgid "Add fields to %s"
+msgstr ""
+
+#. translators: %s options page name
+#: pro/admin/post-types/admin-ui-options-page.php:89
+msgid "%s options page created"
+msgstr "%s のオプションページを作成しました"
+
+#: pro/admin/post-types/admin-ui-options-page.php:102
+msgid "Link existing field groups"
+msgstr "フィールドグループを編集"
+
+#: pro/admin/post-types/admin-ui-options-page.php:131
+msgid "Post"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:132
+msgid "Posts"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:133
+msgid "Page"
+msgstr "ページ"
+
+#: pro/admin/post-types/admin-ui-options-page.php:134
+msgid "Pages"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:135
+msgid "Default"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:157
+msgid "Basic Settings"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:158
+msgid "Advanced Settings"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:283
+msgctxt "post status"
+msgid "Active"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:283
+msgctxt "post status"
+msgid "Inactive"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:361
+msgid "No Parent"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-page.php:450
+msgid "The provided Menu Slug already exists."
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-pages.php:114
+msgid "Key"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-pages.php:118
+msgid "Local JSON"
+msgstr ""
+
+#: pro/admin/post-types/admin-ui-options-pages.php:147
+msgid "No description"
+msgstr "説明がありません"
+
+#. translators: %s number of post types activated
+#: pro/admin/post-types/admin-ui-options-pages.php:175
+msgid "Options page activated."
+msgid_plural "%s options pages activated."
+msgstr[0] "%s のオプションページを有効しました"
+
+#. translators: %s number of post types deactivated
+#: pro/admin/post-types/admin-ui-options-pages.php:182
+msgid "Options page deactivated."
+msgid_plural "%s options pages deactivated."
+msgstr[0] "%s のオプションを無効しました"
+
+#. translators: %s number of post types duplicated
+#: pro/admin/post-types/admin-ui-options-pages.php:189
+msgid "Options page duplicated."
+msgid_plural "%s options pages duplicated."
+msgstr[0] ""
+
+#. translators: %s number of post types synchronized
+#: pro/admin/post-types/admin-ui-options-pages.php:196
+msgid "Options page synchronized."
+msgid_plural "%s options pages synchronized."
+msgstr[0] ""
+
+#: pro/admin/views/html-settings-updates.php:9
 msgid "Deactivate License"
 msgstr "ライセンスのアクティベートを解除"
 
-#: pro/admin/views/html-settings-updates.php:6
+#: pro/admin/views/html-settings-updates.php:9
 msgid "Activate License"
 msgstr "ライセンスをアクティベート"
 
-#: pro/admin/views/html-settings-updates.php:16
+#: pro/admin/views/html-settings-updates.php:26
+msgctxt "license status"
+msgid "Inactive"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:35
+msgctxt "license status"
+msgid "Cancelled"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:33
+msgctxt "license status"
+msgid "Expired"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:31
+msgctxt "license status"
+msgid "Active"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:48
+msgid "Subscription Status"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:46
+msgid "License Status"
+msgstr "ライセンスキー"
+
+#: pro/admin/views/html-settings-updates.php:61
+msgid "Subscription Type"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:59
+msgid "License Type"
+msgstr "ライセンス類"
+
+#: pro/admin/views/html-settings-updates.php:68
+msgid "Lifetime - "
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:82
+msgid "Subscription Expires"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:80
+msgid "Subscription Expired"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:119
+msgid "Renew Subscription"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:137
 msgid "License Information"
 msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:34
-msgid ""
-"To unlock updates, please enter your license key below. If you don't have a "
-"licence key, please see <a href=\"%s\" target=\"_blank\">details & pricing</"
-"a>."
-msgstr ""
-
-#: pro/admin/views/html-settings-updates.php:37
+#: pro/admin/views/html-settings-updates.php:172
 msgid "License Key"
 msgstr "ライセンスキー"
 
-#: pro/admin/views/html-settings-updates.php:22
+#: pro/admin/views/html-settings-updates.php:194, pro/admin/views/html-settings-updates.php:158
+msgid "Recheck License"
+msgstr "ライセンスのアクティベートを再度確認"
+
+#: pro/admin/views/html-settings-updates.php:143
 msgid "Your license key is defined in wp-config.php."
 msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:29
-msgid "Retry Activation"
+#: pro/admin/views/html-settings-updates.php:215
+msgid "View pricing & purchase"
 msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:61
-msgid "Update Information"
-msgstr "アップデート情報"
+#. translators: %s - link to ACF website
+#: pro/admin/views/html-settings-updates.php:224
+msgid "Don't have an ACF PRO license? %s"
+msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:68
+#: pro/admin/views/html-settings-updates.php:239
+msgid "Update Information"
+msgstr "情報を更新"
+
+#: pro/admin/views/html-settings-updates.php:246
 msgid "Current Version"
 msgstr "現在のバージョン"
 
-#: pro/admin/views/html-settings-updates.php:76
+#: pro/admin/views/html-settings-updates.php:254
 msgid "Latest Version"
 msgstr "最新のバージョン"
 
-#: pro/admin/views/html-settings-updates.php:84
+#: pro/admin/views/html-settings-updates.php:262
 msgid "Update Available"
 msgstr "利用可能なアップデート"
 
-#: pro/admin/views/html-settings-updates.php:91
+#: pro/admin/views/html-settings-updates.php:269
 msgid "No"
 msgstr "いいえ"
 
-#: pro/admin/views/html-settings-updates.php:89
+#: pro/admin/views/html-settings-updates.php:267
 msgid "Yes"
 msgstr "はい"
 
-#: pro/admin/views/html-settings-updates.php:98
+#: pro/admin/views/html-settings-updates.php:276
 msgid "Upgrade Notice"
 msgstr "アップグレード通知"
 
-#: pro/admin/views/html-settings-updates.php:126
+#: pro/admin/views/html-settings-updates.php:307
 msgid "Check For Updates"
 msgstr ""
 
-#: pro/admin/views/html-settings-updates.php:121
-#, fuzzy
-#| msgid "Please enter your license key above to unlock updates"
+#: pro/admin/views/html-settings-updates.php:304
 msgid "Enter your license key to unlock updates"
 msgstr "アップデートのロックを解除するためにライセンスキーを入力してください"
 
-#: pro/admin/views/html-settings-updates.php:119
+#: pro/admin/views/html-settings-updates.php:302
 msgid "Update Plugin"
 msgstr "プラグインをアップデート"
 
-#: pro/admin/views/html-settings-updates.php:117
+#: pro/admin/views/html-settings-updates.php:300
+msgid "Updates must be manually installed in this configuration"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:298
+msgid "Update ACF in Network Admin"
+msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:296
 msgid "Please reactivate your license to unlock updates"
 msgstr ""
+
+#: pro/admin/views/html-settings-updates.php:294
+msgid "Please upgrade WordPress to update ACF"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:20
+msgid "Dashicon class name"
+msgstr ""
+
+#. translators: %s = "dashicon class name", link to the WordPress dashicon documentation.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:25
+msgid "The icon used for the options page menu item in the admin dashboard. Can be a URL or %s to use for the icon."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:59
+msgid "Menu Icon"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:80
+msgid "Menu Title"
+msgstr "メニュータイトル"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:94
+msgid "Learn more about menu positions."
+msgstr ""
+
+#. translators: %s - link to WordPress docs to learn more about menu positions.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:98, pro/admin/views/acf-ui-options-page/advanced-settings.php:104
+msgid "The position in the menu where this page should appear. %s"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:108
+msgid "The position in the menu where this child page should appear. The first child page is 0, the next is 1, etc."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:115
+msgid "Menu Position"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:129
+msgid "Redirect to Child Page"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:130
+msgid "When child pages exist for this parent page, this page will redirect to the first child page."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:154
+msgid "A descriptive summary of the options page."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:163
+msgid "Update Button Label"
+msgstr "ボタンのラベルを更新"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:164
+msgid "The label used for the submit button which updates the fields on the options page."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:178
+msgid "Updated Message"
+msgstr "メッセージを更新しました"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:179
+msgid "The message that is displayed after successfully updating the options page."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:180
+msgid "Updated Options"
+msgstr "オプションを更新しました"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:217
+msgid "Capability"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:218
+msgid "The capability required for this menu to be displayed to the user."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:234
+msgid "Data Storage"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:235
+msgid "By default, the option page stores field data in the options table. You can make the page load field data from a post, user, or term."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:238, pro/admin/views/acf-ui-options-page/advanced-settings.php:269
+msgid "Custom Storage"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:258
+msgid "Learn more about available settings."
+msgstr ""
+
+#. translators: %s = link to learn more about storage locations.
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:263
+msgid "Set a custom storage location. Can be a numeric post ID (123), or a string (`user_2`). %s"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:288
+msgid "Autoload Options"
+msgstr "オプションをオートロード"
+
+#: pro/admin/views/acf-ui-options-page/advanced-settings.php:289
+msgid "Improve performance by loading the fields in the option records automatically when WordPress loads."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:20, pro/admin/views/acf-ui-options-page/create-options-page-modal.php:16
+msgid "Page Title"
+msgstr "ページタイトル"
+
+#. translators: example options page name
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:22, pro/admin/views/acf-ui-options-page/create-options-page-modal.php:18
+msgid "Site Settings"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:37, pro/admin/views/acf-ui-options-page/create-options-page-modal.php:33
+msgid "Menu Slug"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:52, pro/admin/views/acf-ui-options-page/create-options-page-modal.php:47
+msgid "Parent Page"
+msgstr "親ページ"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:72
+msgid "Advanced Configuration"
+msgstr "詳細設定"
+
+#: pro/admin/views/acf-ui-options-page/basic-settings.php:73
+msgid "I know what I'm doing, show me all the options."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:62
+msgid "Cancel"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/create-options-page-modal.php:63
+msgid "Done"
+msgstr ""
+
+#. translators: %s URL to ACF options pages documentation
+#: pro/admin/views/acf-ui-options-page/list-empty.php:10
+msgid "ACF <a href=\"%s\" target=\"_blank\">options pages</a> are custom admin pages for managing global settings via fields. You can create multiple pages and sub-pages."
+msgstr ""
+
+#. translators: %s url to getting started guide
+#: pro/admin/views/acf-ui-options-page/list-empty.php:16
+msgid "New to ACF? Take a look at our <a href=\"%s\" target=\"_blank\">getting started guide</a>."
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:32
+msgid "Upgrade to ACF PRO to create options pages in just a few clicks"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:30
+msgid "Add Your First Options Page"
+msgstr "最初のオプションページを追加"
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:43
+msgid "Learn More"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:44
+msgid "Upgrade to ACF PRO"
+msgstr ""
+
+#: pro/admin/views/acf-ui-options-page/list-empty.php:40
+msgid "Add Options Page"
+msgstr "オプションページを追加"
+
+#: src/pro/Fields/FlexibleContent/Layout.php:243
+msgid "Disabled"
+msgstr "無効化"
+
+#: src/pro/Fields/FlexibleContent/Layout.php:249
+msgid "More layout actions..."
+msgstr "その他のアクション..."
+
+#: src/pro/Fields/FlexibleContent/Layout.php:251
+msgid "Toggle layout"
+msgstr "レイアウトを切り替え"
+
+#. translators: %s the button label used for adding a new layout.
+#: src/pro/Fields/FlexibleContent/Render.php:113
+msgid "Click the \"%s\" button below to start creating your layout"
+msgstr "下の \"%s\" ボタンをクリックしてレイアウトの作成を始めてください"
+
+#: src/pro/Fields/FlexibleContent/Render.php:192
+msgid "Expand All"
+msgstr "すべてを展開"
+
+#: src/pro/Fields/FlexibleContent/Render.php:195
+msgid "Collapse All"
+msgstr "すべてを折りたたむ"
+
+#: src/pro/Fields/FlexibleContent/Render.php:257
+msgid "Disable"
+msgstr "無効化"
+
+#: src/pro/Fields/FlexibleContent/Render.php:260
+msgid "Enable"
+msgstr "有効化"


### PR DESCRIPTION
Merged `acf.pot` into `acf-ja.po` for ACF version 6.5.1.
Some existing strings were updated.
Some strings were added (mainly strings used by editors on content-types).