### PR TITLE
Undefined array key “value” in abstract-acf-location.php

### DIFF
--- a/includes/locations/abstract-acf-location.php
+++ b/includes/locations/abstract-acf-location.php
@@ -180,6 +180,10 @@ if ( ! class_exists( 'ACF_Location' ) ) :
 		 * @return  boolean
 		 */
 		public function compare_to_rule( $value, $rule ) {
+			if ( !isset($rule['value']) ) {
+				return false;
+			}
+
 			$result = ( $value == $rule['value'] );
 
 			// Allow "all" to match any value.


### PR DESCRIPTION
see https://support.advancedcustomfields.com/forums/topic/undefined-array-key-value-in-abstract-acf-location-php/

On the same note: What do you think about adding an additional rule that allows us to never show a field group? Would be great for field groups solely used by clone fields. 