### PR TITLE
Add missing fr_FR translations for flexible content layout strings

### DIFF
--- a/lang/acf-fr_FR.po
+++ b/lang/acf-fr_FR.po
@@ -85,8 +85,9 @@ msgid "AI Support"
 msgstr ""
 
 #: src/Site_Health/Site_Health.php:396
+#: src/Pro/Fields/FlexibleContent/Layout.php:247
 msgid "Disabled"
-msgstr ""
+msgstr "Désactivé"
 
 #: src/Site_Health/Site_Health.php:395
 msgid "Enabled"

--- a/lang/pro/acf-fr_FR.po
+++ b/lang/pro/acf-fr_FR.po
@@ -388,6 +388,42 @@ msgstr "Supprimer la disposition"
 msgid "Duplicate Layout"
 msgstr "Dupliquer la disposition"
 
+#: pro/fields/class-acf-field-flexible-content.php:99
+msgid "Delete %s"
+msgstr "Supprimer %s"
+
+#: pro/fields/class-acf-field-flexible-content.php:102
+msgid "Are you sure you want to delete %s?"
+msgstr "Êtes-vous sûr de vouloir supprimer %s ?"
+
+#: src/Pro/Fields/FlexibleContent/Layout.php:253
+msgid "More layout actions..."
+msgstr "Plus d'actions..."
+
+#: src/Pro/Fields/FlexibleContent/Layout.php:255
+msgid "Toggle layout"
+msgstr "Afficher/masquer la disposition"
+
+#: src/Pro/Fields/FlexibleContent/Render.php:197
+msgid "Expand All"
+msgstr "Tout développer"
+
+#: src/Pro/Fields/FlexibleContent/Render.php:200
+msgid "Collapse All"
+msgstr "Tout réduire"
+
+#: src/Pro/Fields/FlexibleContent/Render.php:257
+msgid "Rename"
+msgstr "Renommer"
+
+#: src/Pro/Fields/FlexibleContent/Render.php:262
+msgid "Disable"
+msgstr "Désactiver"
+
+#: src/Pro/Fields/FlexibleContent/Render.php:265
+msgid "Enable"
+msgstr "Activer"
+
 # @ acf
 #: pro/fields/class-acf-field-flexible-content.php:564
 msgid "Add New Layout"


### PR DESCRIPTION
## Summary
- Adds French (fr_FR) translations for several strings used in the Flexible Content field that were previously untranslated:
  - Pro: `Delete %s`, `Are you sure you want to delete %s?`, `More layout actions...`, `Toggle layout`, `Expand All`, `Collapse All`, `Rename`, `Disable`, `Enable`
  - Free: `Disabled` (existing entry had an empty `msgstr`), also referenced from `src/Pro/Fields/FlexibleContent/Layout.php`

## Test plan
- [ ] Confirm strings render correctly in the ACF admin UI with `fr_FR` locale active