### PR TITLE
Fix hidden acf_after_title meta box drop target corrupting user box order

### DIFF
--- a/includes/forms/form-post.php
+++ b/includes/forms/form-post.php
@@ -203,7 +203,9 @@ if ( ! class_exists( 'ACF_Form_Post' ) ) :
 			);
 
 			// render 'acf_after_title' metaboxes
-			do_meta_boxes( get_current_screen(), 'acf_after_title', $post );
+			if ( isset( $wp_meta_boxes[ get_current_screen()->id ]['acf_after_title'] ) ) {
+				do_meta_boxes( get_current_screen(), 'acf_after_title', $post );
+			}
 
 			$style = '';
 			if ( is_string( $this->style ) ) {


### PR DESCRIPTION
Fix for https://github.com/AdvancedCustomFields/acf/issues/1029

ACF_Form_Post::edit_form_after_title() called do_meta_boxes( ..., 'acf_after_title', ... ) unconditionally, which always emits an empty #acf_after_title-sortables container when no field groups use that position. On block editor screens this container lives inside the hidden .metabox-base-form, yet postboxes.js still registers it as a jQuery UI droppable, so dragging any meta box reveals a phantom drop zone (body.is-dragging-metaboxes styling) and drops are persisted to meta-box-order_{$screen} user meta under acf_after_title. On reload, core re-registers those IDs into a context Gutenberg never renders, permanently hiding the box for that user.

Change
Gate the do_meta_boxes( ..., 'acf_after_title', ... ) call on isset( $wp_meta_boxes[ get_current_screen()->id ]['acf_after_title'] ). acf_form_data() remains unconditional so saving still works.